### PR TITLE
Add command to toggle hidden files

### DIFF
--- a/system/toggle-hidden-files.applescript
+++ b/system/toggle-hidden-files.applescript
@@ -1,0 +1,25 @@
+#!/usr/bin/osascript
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Toggle Hidden Files
+# @raycast.mode silent
+
+# Optional parameters:
+# @raycast.icon 👓
+
+try
+	set VisibleFiles to do shell script "defaults read com.apple.finder AppleShowAllFiles"
+on error
+	set VisibleFiles to "1"
+end try
+
+if VisibleFiles is "1" then
+	set NewSet to false
+else
+	set NewSet to true
+end if
+
+do shell script "defaults write com.apple.finder AppleShowAllFiles -bool " & NewSet
+
+do shell script "killall Finder"


### PR DESCRIPTION
# Toggle hidden files
<img width="862" alt="image" src="https://user-images.githubusercontent.com/83694/94742420-f5831e80-0375-11eb-9ed0-2ed9871ec463.png">

# How it works
Open Raycast and type "toggle hidden files".

# Result
On Finder, the user will be able to see hidden files and folder which starts with a dot.

# Screenshots

Difference between hidden files being presented or not

<img width="313" alt="image" src="https://user-images.githubusercontent.com/83694/94742650-59a5e280-0376-11eb-9ba5-1de64c9db9b4.png">

<img width="237" alt="image" src="https://user-images.githubusercontent.com/83694/94742762-83f7a000-0376-11eb-8b1e-21357476d764.png">





