### PR TITLE
fix(Finder & Terminal): iTerm support removed

### DIFF
--- a/navigation/open-finder-from-terminal.applescript
+++ b/navigation/open-finder-from-terminal.applescript
@@ -13,19 +13,11 @@
 # @raycast.author Kirill Gorbachyonok
 # @raycast.authorURL https://github.com/japanese-goblinn
 
-if application "iTerm" is running then
-    tell application "iTerm"
-        tell the current session of current window
-            write text "open -a Finder ./"
-        end tell   
-    end tell
-else
-    tell application "Terminal"
-        if not (exists window 1) then reopen
-            activate
-        if busy of window 1 then
-            tell application "System Events" to keystroke "t" using command down
-        end if
-        do script "open -a Finder ./" in window 1
-    end tell
-end if
+tell application "Terminal"
+    if not (exists window 1) then reopen
+        activate
+    if busy of window 1 then
+        tell application "System Events" to keystroke "t" using command down
+    end if
+    do script "open -a Finder ./" in window 1
+end tell

--- a/navigation/open-terminal-from-finder.applescript
+++ b/navigation/open-terminal-from-finder.applescript
@@ -18,28 +18,7 @@ tell application "Finder"
     set command to "clear; cd " & pathList
 end tell
   
-tell application "System Events"
-    set isRunning to (exists (processes where name is "iTerm")) or (exists (processes where name is "iTerm2"))
-end tell
-  
-if application "iTerm" is running then
-    tell application "iTerm"
-        activate
-        set hasNoWindows to ((count of windows) is 0)
-        if isRunning and hasNoWindows then
-            create window with default profile
-        end if
-        select first window
-
-        tell the first window
-            if isRunning and hasNoWindows is false then
-                create tab with default profile
-            end if
-            tell current session to write text command
-        end tell
-    end tell
-else
-    tell application "Terminal"
+tell application "Terminal"
         if not (exists window 1) then reopen
             activate
         if busy of window 1 then
@@ -47,6 +26,4 @@ else
         end if
         do script command in window 1
     end tell
-end if
-
 


### PR DESCRIPTION
The script fails if iTerm is not installed. Now script will use `Terminal.app` only as a quick fix. iTerm support will be requested in a separate PR 🙂