### PR TITLE
Add Script Command Template: set-screens-preset

### DIFF
--- a/commands/system/set-screens-preset.template.sh
+++ b/commands/system/set-screens-preset.template.sh
@@ -20,6 +20,7 @@ settings=""
 # @raycast.author Caleb Stauffer
 # @raycast.authorURL https://github.com/crstauf
 # @raycast.description Apply preset screen settings.
+# @raycast.packageName System
 # @raycast.icon 🖥️
 
 if ! command -v displayplacer &> /dev/null; then

--- a/commands/system/set-screens-preset.template.sh
+++ b/commands/system/set-screens-preset.template.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Dependency: requires displayplacer (https://github.com/jakehilborn/displayplacer)
+# Install via Homebrew: `brew tap jakehilborn/jakehilborn && brew install displayplacer`
+
+##################################################################
+## Get display ID and settings by running `displayplacer list`, ##
+## find the command, and copy command to `settings` variable.   ##
+##                                                              ##
+## See https://github.com/jakehilborn/displayplacer for help.   ##
+##################################################################
+
+# Display ID and settings
+settings=""
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Set Screens Preset
+# @raycast.mode silent
+# @raycast.author Caleb Stauffer
+# @raycast.authorURL https://github.com/crstauf
+# @raycast.description Apply preset screen settings.
+# @raycast.icon 🖥️
+
+if ! command -v displayplacer &> /dev/null; then
+	echo "displayplacer command is required (https://github.com/jakehilborn/displayplacer).";
+	exit 1;
+fi
+
+displayplacer "$settings"
+displayplacer "$settings" # Running twice is necessary to restore scaling preference.
+
+echo "Applied display preset"


### PR DESCRIPTION
## Description

Introduce a template that uses `jakehilborn/displayplacer` to create presets for system displays. I personally use it to change the orientation of my iMac between landscape and portrait, but much more complex presets can be created.

## Type of change

- [x] New script command

## Screenshot

<img width="757" alt="Screen Shot 2020-11-17 at 9 29 53 AM" src="https://user-images.githubusercontent.com/4573033/99402575-7dd26a00-28b7-11eb-8772-6b77719e4bdb.png">

## Dependencies / Requirements

Requires `jakehilborn/displayplacer` dependency, as well as some config (thus submitting as template).

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)