### PR TITLE
Fix/navigation applications

### DIFF
--- a/commands/README.md
+++ b/commands/README.md
@@ -45,7 +45,7 @@ This repository contains sample commands and documentation to write your own one
 
 | Icon | Title | Description | Author |
 | ---- | ----- | ----------- | ------ |
-| 🔐 | [2FA from iMessages](communication/imessage-2fa.sh) | Get most recent two-factor authentication code from iMessages. | Caleb Stauffer and Thiago Holanda |
+| 🔐 | [2FA from iMessages](communication/imessage-2fa.sh) | Get most recent two-factor authentication code from iMessages. | [Caleb Stauffer](https://github.com/crstauf) and [Thiago Holanda](https://twitter.com/tholanda) |
 | 🔐 | [Generate Passphrase](communication/xkcdpass.sh) | Use xkcdpass to create a passphrase. | [Caleb Stauffer](https://github.com/crstauf) |
 
 #### Cloudup

--- a/commands/extensions.json
+++ b/commands/extensions.json
@@ -1038,8 +1038,12 @@
         {
           "authors" : [
             {
-              "name" : "Caleb Stauffer and Thiago Holanda",
-              "url" : null
+              "name" : "Caleb Stauffer",
+              "url" : "https:\/\/github.com\/crstauf"
+            },
+            {
+              "name" : "Thiago Holanda",
+              "url" : "https:\/\/twitter.com\/tholanda"
             }
           ],
           "currentDirectoryPath" : null,
@@ -1450,5 +1454,5 @@
       ]
     }
   ],
-  "lastUpdate" : "2020-11-17T21:51:02Z"
+  "lastUpdate" : "2020-11-17T22:03:48Z"
 }


### PR DESCRIPTION
## Description

Fix for the "Open Applications" command.
The original command opened `~/Applications` directory, rather than the one of under root (`/Applications`), which is the wrong one.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)