### PR TITLE
Workflow improvements

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -21,16 +21,7 @@ jobs:
 
     - name: Generate Script Commands Documentation
       run: |
-        make gen-docs
-        if `git status | grep -q "nothing to commit"`; then
-          exit 0;
-        else
-          git config --local user.email "bot@raycast.com" &&
-          git config --local user.name "Raycast Bot" &&
-          git add commands/README.md commands/extensions.json &&
-          git commit -m "Update Script Commands documentation" &&
-          exit 0;
-        fi
+        make gen-docs-and-commit
     
     - name: Push changes
       if: success()

--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,27 @@
 EXECUTABLE_NAME = toolkit
 
-BUILD_PATH_RELEASE = Tools/Toolkit/.build/release
+TOOLKIT_PATH = Tools/Toolkit
+BUILD_PATH_RELEASE = $(TOOLKIT_PATH)/.build/release
 EXECUTABLE_PATH_RELEASE = $(BUILD_PATH_RELEASE)/Toolkit
 
-BUILD_PATH_DEBUG = Tools/Toolkit/.build/debug
+BUILD_PATH_DEBUG = $(TOOLKIT_PATH)/.build/debug
 EXECUTABLE_PATH_DEBUG= $(BUILD_PATH_DEBUG)/Toolkit
 
 clean:
-	rm -rf Tools/Toolkit/.build $(EXECUTABLE_NAME)
+	rm -rf $(TOOLKIT_PATH)/.build $(EXECUTABLE_NAME)
 
 build: clean
-	swift build -c release --disable-sandbox --arch x86_64 --package-path Tools/Toolkit
+	swift build -c release --disable-sandbox --arch x86_64 --package-path $(TOOLKIT_PATH)
 	ln -s $(EXECUTABLE_PATH_RELEASE) $(EXECUTABLE_NAME)
 
 build-debug:
 	if [ -f $(EXECUTABLE_NAME) ]; then rm $(EXECUTABLE_NAME); fi
 
-	swift build --package-path Tools/Toolkit
+	swift build --package-path $(TOOLKIT_PATH)
 	ln -s $(EXECUTABLE_PATH_DEBUG) $(EXECUTABLE_NAME)
 
 gen-docs: 
 	./$(EXECUTABLE_NAME) generate-documentation
+
+gen-docs-and-commit: gen-docs
+	./$(TOOLKIT_PATH)/integration.sh commit

--- a/Tools/Toolkit/Sources/ToolkitLibrary/Models/RaycastData.swift
+++ b/Tools/Toolkit/Sources/ToolkitLibrary/Models/RaycastData.swift
@@ -6,6 +6,6 @@
 import Foundation
 
 struct RaycastData: Codable {
-  var lastUpdate = Date()
+  var updatedAt = Date()
   var groups = Groups()
 }

--- a/Tools/Toolkit/integration.sh
+++ b/Tools/Toolkit/integration.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+function commit() {
+  if `git status | grep -q "nothing to commit"`; then
+    exit 0;
+  else
+    extensions=false
+    readme=false
+    
+    extensions_path="commands/extensions.json"
+    readme_path="commands/README.md"
+    
+    while read -r file; do  
+      if [[ $file == $extensions_path ]]; then
+        extensions=true
+      fi
+      
+      if [[ $file == $readme_path ]]; then
+        readme=true
+      fi
+    done <<< "$(git diff --name-only)"
+    
+    if $extensions && $readme; then
+      git config --local user.email "bot@raycast.com"
+      git config --local user.name "Raycast Bot"
+      git add $extensions_path $readme_path
+      git commit -m "Update Script Commands documentation"
+    fi
+    
+    exit 0;
+  fi
+}
+
+argument=$1
+
+if [[ $argument = "commit" ]]; then
+  commit
+fi


### PR DESCRIPTION
## Description

Fixes a small bug when the documents are generated (or regenerated) even without any changes on the script commands, we were committing the `extensions.json` with only the `lastUpdate` changed. 

The intention isn't make any commit using the Raycast Bot if we didn't explicitly made changes in two files: `commands/extensions.json` and `commands/README.md`.  This pull request is fixing that.

## Type of change

Please delete options that are not relevant.

- [x] Toolkit change
            - Renamed `lastUpdate` key to `updatedAt`
- [x] Other:
            - Workflow update

## Screenshot

No apply

## Dependencies / Requirements

No apply

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)