### PR TITLE
Add Script Commands: Spotify Now Playing Song URL to Clipboard #53

### DIFF
--- a/commands/media/spotify/spotify-now-playing-url.applescript
+++ b/commands/media/spotify/spotify-now-playing-url.applescript
@@ -2,7 +2,7 @@
 
 # Required parameters:
 # @raycast.schemaVersion 1
-# @raycast.title Spotify Now Playing Song URL
+# @raycast.title Copy Current Playing Song URL
 # @raycast.mode silent
 
 # Optional parameters:
@@ -21,4 +21,3 @@ set AppleScript's text item delimiters to ":"
 set idPart to third text item of spotifyURL
 
 set the clipboard to ("https://open.spotify.com/track/" & idPart)
-

--- a/commands/media/spotify/spotify-now-playing-url.applescript
+++ b/commands/media/spotify/spotify-now-playing-url.applescript
@@ -7,7 +7,7 @@
 
 # Optional parameters:
 # @raycast.icon images/spotify.png
-
+# @raycast.packageName Spotify
 # Documentation:
 # @raycast.author Jack LaFond
 # @raycast.authorURL https://github.com/jacc

--- a/commands/media/spotify/spotify-now-playing-url.applescript
+++ b/commands/media/spotify/spotify-now-playing-url.applescript
@@ -1,0 +1,24 @@
+#!/usr/bin/osascript
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Spotify Now Playing Song URL
+# @raycast.mode silent
+
+# Optional parameters:
+# @raycast.icon images/spotify.pngs
+
+# Documentation:
+# @raycast.author Jack LaFond
+# @raycast.authorURL https://github.com/jacc
+# @raycast.description Get link to current Spotify playing song
+
+tell application "Spotify"
+	set spotifyURL to spotify url of the current track
+end tell
+
+set AppleScript's text item delimiters to ":"
+set idPart to third text item of spotifyURL
+
+set the clipboard to ("https://open.spotify.com/track/" & idPart)
+

--- a/commands/media/spotify/spotify-now-playing-url.applescript
+++ b/commands/media/spotify/spotify-now-playing-url.applescript
@@ -6,7 +6,7 @@
 # @raycast.mode silent
 
 # Optional parameters:
-# @raycast.icon images/spotify.pngs
+# @raycast.icon images/spotify.png
 
 # Documentation:
 # @raycast.author Jack LaFond


### PR DESCRIPTION
## Description

Allows the current playing Spotify song to be copied as a URL to the clipboard.

## Type of change

- [x] New script command

## Screenshot

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/6956351/99702507-dcd4e200-2a63-11eb-9900-15e25bae6daf.gif)

## Dependencies / Requirements

n/a

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)