### PR TITLE
Fix: use correct Spotify logo in copy now playing script

### DIFF
--- a/commands/media/spotify/spotify-now-playing-url.applescript
+++ b/commands/media/spotify/spotify-now-playing-url.applescript
@@ -6,7 +6,7 @@
 # @raycast.mode silent
 
 # Optional parameters:
-# @raycast.icon images/spotify.png
+# @raycast.icon images/spotify-logo.png
 # @raycast.packageName Spotify
 # Documentation:
 # @raycast.author Jack LaFond


### PR DESCRIPTION
## Description

Switch the `raycast.icon` from `images/spotify.png` to `images/spotify-logo.png`, forgot to use the correct one.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix
- [x] Improvement of an existing script

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)