### PR TITLE
Update emoji-copy.sh to use the new arguments feature

### DIFF
--- a/commands/communication/emojis/emoji-copy.sh
+++ b/commands/communication/emojis/emoji-copy.sh
@@ -4,27 +4,25 @@
 # Install via npm: `npm install --global emoj`
 
 # @raycast.schemaVersion 1
-# @raycast.title Search and Copy First Related Emoji from Clipboard Content
+# @raycast.title Copy Emoji
 # @raycast.mode compact
 # @raycast.author Caleb Stauffer
 # @raycast.authorURL https://github.com/crstauf
-# @raycast.description Copy first emoji related to clipboard content.
+# @raycast.description Copy first emoji related to the typed query.
 # @raycast.packageName Communication
-# @raycast.needsConfirmation true
 # @raycast.icon 📙
+# @raycast.argument1 { "type": "text", "placeholder": "query" }
 
 if ! command -v emoj &> /dev/null; then
 	echo "emoj command is required (https://github.com/sindresorhus/emoj).";
 	exit 1;
 fi
 
-clipboard=$(pbpaste)
-
-emojis=$(emoj -c "$clipboard")
+emojis=$(emoj -c "$1")
 
 if [ -z "$emojis" ]; then
-	echo "No emojis found for \"${clipboard}\""
+	echo "No emojis found for \"$1\""
 	exit 0
 fi
 
-echo "Copied emoji for \"$clipboard\""
+echo "Copied emoji for \"$1\""


### PR DESCRIPTION
## Description

I updated the emoji-copy.sh script to use the new arguments feature. Now it's much easier to search for emojis without having to copy a query in the clipboard first.

![CleanShot 2020-11-20 at 10 44 52](https://user-images.githubusercontent.com/715405/99785503-84621b00-2b1d-11eb-916b-b0bfc4d24f8e.gif)

## Type of change

Please delete options that are not relevant.

- [ ] New script command
- [ ] Bug fix
- [x] Improvement of an existing script
- [ ] Documentation update
- [ ] Toolkit change
- [ ] Other (Specify)

## Screenshot

If it's a new script command, please include a screenshot or a GIF of how it works.

## Dependencies / Requirements

If it's a new script command that requires some additional steps to make it work, please describe it here. E.g. requiring installation of another command line tool or requirement to specify username / API token / etc.

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)