### PR TITLE
Add script command: Define a word

### DIFF
--- a/commands/system/define-word.swift
+++ b/commands/system/define-word.swift
@@ -15,13 +15,13 @@
 
 import Foundation
 
-if CommandLine.argc != 2 {
-  print("Must pass 1 word to define")
-} else {
+if CommandLine.argc > 1 {
   let argument = CommandLine.arguments[1].lowercased()
 
   // https://developer.apple.com/library/archive/documentation/UserExperience/Conceptual/DictionaryServicesProgGuide/access/access.html#//apple_ref/doc/uid/TP40006152-CH5-SW3
   let result = DCSCopyTextDefinition(nil, argument as CFString, CFRangeMake(0, argument.count))?.takeRetainedValue() as String?
 
   print(result ?? "No definition found")
+} else {
+  print("Must pass 1 word to define") 
 }

--- a/commands/system/define-word.swift
+++ b/commands/system/define-word.swift
@@ -1,0 +1,27 @@
+#!/usr/bin/swift
+
+// Required parameters:
+// @raycast.schemaVersion 1
+// @raycast.title Define Word
+// @raycast.author Jesse Claven
+// @raycast.authorURL https://github.com/jesse-c
+// @raycast.description Define a word using the built-in dictionary/dicionaries.
+// @raycast.packageName System
+// @raycast.mode fullOutput
+//
+// Optional parameters:
+// @raycast.icon 🗣
+// @raycast.argument1 { "type": "text", "placeholder": "Word (e.g. isthmus)" }
+
+import Foundation
+
+if CommandLine.argc != 2 {
+  print("Must pass 1 word to define")
+} else {
+  let argument = CommandLine.arguments[1].lowercased()
+
+  // https://developer.apple.com/library/archive/documentation/UserExperience/Conceptual/DictionaryServicesProgGuide/access/access.html#//apple_ref/doc/uid/TP40006152-CH5-SW3
+  let result = DCSCopyTextDefinition(nil, argument as CFString, CFRangeMake(0, argument.count))?.takeRetainedValue() as String?
+
+  print(result ?? "No definition found")
+}


### PR DESCRIPTION
## Description

It adds a script command for looking up the definition of a word using the macOS dictionary.

## Type of change

Please delete options that are not relevant.

- [x] New script command
- [ ] Bug fix
- [ ] Improvement of an existing script
- [ ] Documentation update
- [ ] Toolkit change
- [ ] Other (Specify)

## Screenshot

<img width="862" alt="Screen Shot 2020-11-22 at 1 43 29 pm" src="https://user-images.githubusercontent.com/1405676/99905477-dabf8d00-2cc8-11eb-89fc-2c24cc90fe8b.png">

## Dependencies / Requirements

N/A
## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)