### PR TITLE
Add Script Command: human-date-to-epoch & Add argument support for epoch-to-human-date

### DIFF
--- a/commands/conversions/epoch-to-human-date.sh
+++ b/commands/conversions/epoch-to-human-date.sh
@@ -9,14 +9,15 @@
 # @raycast.icon ⏱
 # @raycast.packageName Conversions
 # @raycast.needsConfirmation false
+# @raycast.argument1 {"type": "text", "placeholder": "Timestamp Epoch"}
 #
 # Documentation:
 # @raycast.description Convert epoch to human-readable date.
 # @raycast.author Siyuan Zhang
 # @raycast.authorURL https://github.com/kastnerorz
 
-epoch=$(pbpaste)
+epoch=${1}
 human=$(echo `date -r $epoch "+%F %T"`)
-echo "$human" | pbcopy
+echo -n "$human" | pbcopy
 
 echo "Converted $epoch to $human" 

--- a/commands/conversions/human-date-to-epoch.sh
+++ b/commands/conversions/human-date-to-epoch.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Convert Human-Readable Date To Epoch
+# @raycast.mode silent
+#
+# Optional parameters:
+# @raycast.icon ⏱
+# @raycast.packageName Conversions
+# @raycast.needsConfirmation false
+# @raycast.argument1 {"type": "text", "placeholder": "Date"}
+#
+# Documentation:
+# @raycast.description Convert human-readable date to timestamp epoch.
+# @raycast.author Siyuan Zhang
+# @raycast.authorURL https://github.com/kastnerorz
+
+date=${1}
+epoch=$(echo `date -jRuf "%F %T" "$date" "+%s"`)
+echo -n "$epoch" | pbcopy
+
+echo "Converted $date to $epoch" 


### PR DESCRIPTION
## Description

- **Add Script Command**: human-date-to-epoch
- **Improvement**: Add argument support for epoch-to-human-date
- **Improvement**: add `-n` argument to echo when copy to clipboard, script won't print the trailing newline character anymore.

## Type of change

Please delete options that are not relevant.

- [x] New script command
- [x] Improvement of an existing script

## Screenshot
`date` is the shortcut set for epoch-to-human-date [**Already Have**]
`unix` is the shortcut set for human-date-to-epoch [**New Script**]
![ezgif-7-df06f67b4120](https://user-images.githubusercontent.com/26199342/99937005-8a672e80-2d9f-11eb-961f-d18dde2ae9a1.gif)

## Dependencies / Requirements

No dependencies required.

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)