### PR TITLE
Add Script Commands: Cmus

### DIFF
--- a/commands/media/cmus/next-track.sh
+++ b/commands/media/cmus/next-track.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# @raycast.schemaVersion 1
+# @raycast.title Next Track
+# @raycast.mode silent
+#
+# @raycast.icon ⏩
+# @raycast.packageName Cmus
+#
+# @raycast.description Goes forward a track if cmus is running
+# @raycast.author mmerle
+# @raycast.authorURL https://github.com/mmerle
+
+
+cmus-remote --next

--- a/commands/media/cmus/play-pause.sh
+++ b/commands/media/cmus/play-pause.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# @raycast.schemaVersion 1
+# @raycast.title Toggle Play/Pause
+# @raycast.mode silent
+#
+# @raycast.icon ⏯
+# @raycast.packageName Cmus
+#
+# @raycast.description Toggles the play/pause state if cmus is running
+# @raycast.author mmerle
+# @raycast.authorURL https://github.com/mmerle
+
+cmus-remote --pause

--- a/commands/media/cmus/previous-track.sh
+++ b/commands/media/cmus/previous-track.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# @raycast.schemaVersion 1
+# @raycast.title Previous Track
+# @raycast.mode silent
+#
+# @raycast.icon ⏪
+# @raycast.packageName Cmus
+#
+# @raycast.description Goes back a track if cmus is running
+# @raycast.author mmerle
+# @raycast.authorURL https://github.com/mmerle
+
+cmus-remote --prev

--- a/commands/media/cmus/toggle-repeat.sh
+++ b/commands/media/cmus/toggle-repeat.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# @raycast.schemaVersion 1
+# @raycast.title Toggle Repeat
+# @raycast.mode silent
+#
+# @raycast.icon 🔁
+# @raycast.packageName Cmus
+#
+# @raycast.description Toggles the repeat option if cmus is running
+# @raycast.author mmerle
+# @raycast.authorURL https://github.com/mmerle
+
+
+cmus-remote --repeat

--- a/commands/media/cmus/toggle-shuffle.sh
+++ b/commands/media/cmus/toggle-shuffle.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# @raycast.schemaVersion 1
+# @raycast.title Toggle Shuffle
+# @raycast.mode silent
+#
+# @raycast.icon 🔀
+# @raycast.packageName Cmus
+#
+# @raycast.description Toggles the shuffle option if cmus is running
+# @raycast.author mmerle
+# @raycast.authorURL https://github.com/mmerle
+
+
+cmus-remote --shuffle

--- a/commands/media/cmus/track-info.sh
+++ b/commands/media/cmus/track-info.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# @raycast.schemaVersion 1
+# @raycast.title Current Track
+# @raycast.mode inline
+# @raycast.refreshTime 10s
+#
+# @raycast.icon ℹ️
+# @raycast.packageName Cmus
+#
+# @raycast.description Shows info on the current track if cmus is running
+# @raycast.author mmerle
+# @raycast.authorURL https://github.com/mmerle
+#
+# Modified script from https://github.com/Anachron/i3blocks/blob/master/blocks/cmus
+
+
+cmus-remote >& /dev/null
+if [[ $? -eq 0 ]]; then
+  info_cmus=$(cmus-remote -Q)
+  info_status=$(echo "${info_cmus}" | sed -n -e 's/^.*status//p' | head -n 1)
+  track_title=$(echo "${info_cmus}" | sed -n -e 's/^.*title//p' | head -n 1)
+  track_artist=$(echo "${info_cmus}" | sed -n -e 's/^.*artist//p' | head -n 1)
+  track_album=$(echo "${info_cmus}" | sed -n -e 's/^.*album//p' | head -n 1)
+    if [[ $info_status == *"playing"* ]]; then
+        out_text="${track_title} —${track_artist}"
+    else
+        out_text="[PAUSED] ${track_title} —${track_artist}"
+    fi
+else
+  out_text="Cmus is not running"
+fi
+
+echo ${out_text}


### PR DESCRIPTION
## Description

Adds script commands to control cmus music player.

## Type of change

- [x] New script command
- [ ] Bug fix
- [ ] Improvement of an existing script
- [ ] Documentation update
- [ ] Toolkit change
- [ ] Other (Specify)

## Screenshot

![Screen Shot 2020-11-24 at 10 08 29 PM](https://user-images.githubusercontent.com/35971019/100179594-60e3fb00-2ea4-11eb-8b62-5381be920d22.png)


## Dependencies / Requirements

[Cmus](https://github.com/cmus/cmus) music player can be downloaded through Homebrew:
   ```bash
brew install cmus
   ```

## Checklist

- [X] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)