### PR TITLE
Reload CoreAudio script

### DIFF
--- a/commands/system/reload-coreaudio.sh
+++ b/commands/system/reload-coreaudio.sh
@@ -1,0 +1,14 @@
+#!/bin/zsh
+
+# @raycast.schemaVersion 1
+# @raycast.title Reload CoreAudio
+# @raycast.mode silent
+# @raycast.author Maxim Krouk
+# @raycast.authorURL https://github.com/maximkrouk
+# @raycast.description Reloads CoreAudio.
+# @raycast.icon 🎧
+# @raycast.packageName System
+
+sudo launchctl stop com.apple.audio.coreaudiod && sudo launchctl start com.apple.audio.coreaudiod
+echo "Done"
+


### PR DESCRIPTION
## Description

A new script, that fixes quality troubles with (at least) Bluetooth earphones by reloading `coreaudiod` process

## Type of change

- [x] New script command

## Screenshot

<img width="862" alt="Screen Shot 2020-11-25 at 16 57 36" src="https://user-images.githubusercontent.com/40476363/100236927-562a7400-2f3f-11eb-9213-98102cbaef67.png">
<p align="center">
<img width="92" alt="Screen Shot 2020-11-25 at 16 59 05" src="https://user-images.githubusercontent.com/40476363/100237116-8a059980-2f3f-11eb-9c26-952b5750215b.png">
</p>


## Dependencies / Requirements

None

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)