### PR TITLE
Output message added to copy current track URL script

### DIFF
--- a/commands/media/spotify/spotify-now-playing-url.applescript
+++ b/commands/media/spotify/spotify-now-playing-url.applescript
@@ -22,3 +22,4 @@ set AppleScript's text item delimiters to ":"
 set idPart to third text item of spotifyURL
 
 set the clipboard to ("https://open.spotify.com/track/" & idPart)
+log "Copied to clipboard"


### PR DESCRIPTION
## Description

Script has an effect on the system (inserts data to the clipboard), but this effect is not visible to user like `playNextTrack` for example (user can see the result of the script immediately (next track is playing), so the message may be needed, but at least not required).

- [x] Improvement of an existing script

## Screenshot
<p align="center">
<img width="190" alt="Screen Shot 2020-11-27 at 10 07 00" src="https://user-images.githubusercontent.com/40476363/100420883-4d998100-3098-11eb-91f4-fc45385ed8e1.png">
</p>

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)