### PR TITLE
Generate password command is not correctly handling missing `gpg`

### DIFF
--- a/commands/developer-utils/generate-password.sh
+++ b/commands/developer-utils/generate-password.sh
@@ -14,8 +14,7 @@
 
 if ! command -v gpg &> /dev/null; then
 	echo "gpg command is required (https://www.gnupg.org/).";
-	exit 1;
+else
+    gpg --gen-random -a 0 30 | pbcopy
+    echo "Password Generated"
 fi
-
-gpg --gen-random -a 0 30 | pbcopy
-echo "Password Generated"

--- a/commands/developer-utils/generate-password.sh
+++ b/commands/developer-utils/generate-password.sh
@@ -14,7 +14,8 @@
 
 if ! command -v gpg &> /dev/null; then
 	echo "gpg command is required (https://www.gnupg.org/).";
-else
-    gpg --gen-random -a 0 30 | pbcopy
-    echo "Password Generated"
+    exit 0;
 fi
+
+gpg --gen-random -a 0 30 | pbcopy
+echo "Password Generated"


### PR DESCRIPTION
## Description

Generate password command is not correctly handling missing `gpg`
https://github.com/raycast/script-commands/issues/119

## Type of change
- [X] Bug fix

## Dependencies / Requirements

## Checklist
- [X] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)