### PR TITLE
Add Script Command: wordpress-cli-command

### DIFF
--- a/commands/web-searches/wordpress/wordpress-classes-reference.sh
+++ b/commands/web-searches/wordpress/wordpress-classes-reference.sh
@@ -12,4 +12,4 @@
 
 # @raycast.argument1 { "type": "text", "placeholder": "Class name" }
 
-open "https://developer.wordpress.org/reference/classes//${1// /%20}/"
+open "https://developer.wordpress.org/reference/classes/${1// /%20}/"

--- a/commands/web-searches/wordpress/wordpress-cli-command.sh
+++ b/commands/web-searches/wordpress/wordpress-cli-command.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# @raycast.title WordPress CLI Command
+# @raycast.author Caleb Stauffer
+# @raycast.authorURL https://github.com/crstauf
+# @raycast.description Open [WordPress CLI command reference](https://developer.wordpress.org/cli/commands/) for specified command.
+
+# @raycast.icon images/wordpress-logo.png
+# @raycast.mode silent
+# @raycast.packageName WordPress
+# @raycast.schemaVersion 1
+
+# @raycast.argument1 { "type": "text", "placeholder": "Command" }
+
+open "https://developer.wordpress.org/cli/commands/${1// /%20}/"

--- a/commands/web-searches/wordpress/wordpress-functions-reference.sh
+++ b/commands/web-searches/wordpress/wordpress-functions-reference.sh
@@ -12,4 +12,4 @@
 
 # @raycast.argument1 { "type": "text", "placeholder": "Function name" }
 
-open "https://developer.wordpress.org/reference/functions//${1// /%20}/"
+open "https://developer.wordpress.org/reference/functions/${1// /%20}/"

--- a/commands/web-searches/wordpress/wordpress-hooks-reference.sh
+++ b/commands/web-searches/wordpress/wordpress-hooks-reference.sh
@@ -12,4 +12,4 @@
 
 # @raycast.argument1 { "type": "text", "placeholder": "Hook name" }
 
-open "https://developer.wordpress.org/reference/hooks//${1// /%20}/"
+open "https://developer.wordpress.org/reference/hooks/${1// /%20}/"


### PR DESCRIPTION
## Description

<!-- Please write a short summary for this change. If it's a new script command, explain what it does. -->

Mistakenly did not add script for access to WP CLI commands reference on #126.

Also removes unnecessary slash from URLs.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New script command
- [x] Improvement of an existing script

## Screenshot

<!-- If it's a new script command, please include a screenshot or a GIF of how it works. -->

<img width="771" alt="Screen Shot 2020-11-30 at 4 29 37 PM" src="https://user-images.githubusercontent.com/4573033/100668037-4937c700-3329-11eb-9a08-199ddbc9ce9e.png">

## Dependencies / Requirements

<!-- If it's a new script command that requires some additional steps to make it work, please describe it here. E.g. requiring installation of another command line tool or requirement to specify username / API token / etc. -->

- `open`

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)