### PR TITLE
Add specificity to description of wallpaper-refresh script

### DIFF
--- a/commands/system/wallpaper-refresh.applescript
+++ b/commands/system/wallpaper-refresh.applescript
@@ -3,7 +3,7 @@
 # @raycast.title Refresh Wallpaper
 # @raycast.author Caleb Stauffer
 # @raycast.authorURL https://github.com/crstauf
-# @raycast.description Refresh the current display's wallpaper.
+# @raycast.description Refresh the wallpaper of the main display's current [Space](https://support.apple.com/guide/mac-help/work-in-multiple-spaces-mh14112/mac).
 
 # @raycast.icon 🖼️
 # @raycast.mode silent


### PR DESCRIPTION
## Description

<!-- Please write a short summary for this change. If it's a new script command, explain what it does. -->

I think this worked for the currently focused display, but now seems to only work for the current Space of the main/primary display; adding clarity to the script's description.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Documentation update

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)