### PR TITLE
Fix WP CLI command search

### DIFF
--- a/commands/web-searches/wordpress/wordpress-cli-command.sh
+++ b/commands/web-searches/wordpress/wordpress-cli-command.sh
@@ -12,4 +12,4 @@
 
 # @raycast.argument1 { "type": "text", "placeholder": "Command" }
 
-open "https://developer.wordpress.org/cli/commands/${1// /%20}/"
+open "https://developer.wordpress.org/cli/commands/${1// //}/"


### PR DESCRIPTION
## Description

<!-- Please write a short summary for this change. If it's a new script command, explain what it does. -->

Adjust string replace to replace each space in input value with a forward slash (because there are no spaces in WP CLI commands).

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Improvement of an existing script

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)