### PR TITLE
Revert string replace in wpengine-install

### DIFF
--- a/commands/web-searches/wpengine-install.sh
+++ b/commands/web-searches/wpengine-install.sh
@@ -12,4 +12,4 @@
 
 # @raycast.argument1 { "type": "text", "placeholder": "Install" }
 
-open "https://my.wpengine.com/installs/${1// /%20}"
+open "https://my.wpengine.com/installs/${1// /}"


### PR DESCRIPTION
## Description

<!-- Please write a short summary for this change. If it's a new script command, explain what it does. -->

Revert incorrect change by @PitNikola in 4e33263f6d1f37d3fa03423a75875ca22bcec5b3. WP Engine installs do not have spaces, so any space should be removed from the install name.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Other (Specify)

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)