### PR TITLE
add url decode/encode and escape-shell scripts

### DIFF
--- a/commands/developer-utils/decode-url.sh
+++ b/commands/developer-utils/decode-url.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Decode URL
+# @raycast.mode silent
+# @raycast.packageName Developer Utilities
+
+# Optional parameters:
+# @raycast.icon 💻
+
+# Documentation:
+# @raycast.description Decodes clipboard content url and copies it again.
+
+function urldecode() {
+    local url_encoded="${1//+/ }"
+    printf '%b' "${url_encoded//%/\\x}"
+}
+
+urldecode $(pbpaste) | pbcopy
+echo "Decoded URL"

--- a/commands/developer-utils/encode-url.sh
+++ b/commands/developer-utils/encode-url.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Encode URL
+# @raycast.mode silent
+# @raycast.packageName Developer Utilities
+
+# Optional parameters:
+# @raycast.icon 💻
+
+# Documentation:
+# @raycast.description Encodes clipboard content url and copies it again.
+
+pbpaste | ( curl -Gso /dev/null -w %{url_effective} --data-urlencode @- "" | cut -c 3- || true) | pbcopy
+echo "Encoded URL"

--- a/commands/developer-utils/escape-shell-chars.sh
+++ b/commands/developer-utils/escape-shell-chars.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Escape shell string
+# @raycast.mode silent
+# @raycast.packageName Developer Utilities
+
+# Optional parameters:
+# @raycast.icon 💻
+
+# Documentation:
+# @raycast.description Escapes shell character string and copies it again.
+
+escaped=$(pbpaste) && printf '%q' "$escaped" | pbcopy
+echo "Encoded URL"

--- a/commands/developer-utils/escape-shell-chars.sh
+++ b/commands/developer-utils/escape-shell-chars.sh
@@ -13,4 +13,4 @@
 # @raycast.description Escapes shell character string and copies it again.
 
 escaped=$(pbpaste) && printf '%q' "$escaped" | pbcopy
-echo "Escaped shell string"
+echo "Escaped string for shell"

--- a/commands/developer-utils/escape-shell-chars.sh
+++ b/commands/developer-utils/escape-shell-chars.sh
@@ -13,4 +13,4 @@
 # @raycast.description Escapes shell character string and copies it again.
 
 escaped=$(pbpaste) && printf '%q' "$escaped" | pbcopy
-echo "Encoded URL"
+echo "Escaped shell string"

--- a/commands/developer-utils/escape-shell-chars.sh
+++ b/commands/developer-utils/escape-shell-chars.sh
@@ -2,7 +2,7 @@
 
 # Required parameters:
 # @raycast.schemaVersion 1
-# @raycast.title Escape shell string
+# @raycast.title Escape String for Shell
 # @raycast.mode silent
 # @raycast.packageName Developer Utilities
 


### PR DESCRIPTION
## Description

PR adds three new scripts, one for decoding URLs, one for encoding URLs, and one script for escaping shell characters. The last one is especially handy for me when copying paths from remote servers and wanting to paste them with escaped backspaces.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New script command
- [ ] Bug fix
- [ ] Improvement of an existing script
- [ ] Documentation update
- [ ] Toolkit change
- [ ] Other (Specify)

## Screenshot

<!-- If it's a new script command, please include a screenshot or a GIF of how it works. -->
The first two should be self-explanatory, so I'm only attaching the last one. Please let me know if you want gifs for the first two as well.

Escaping shell
![CleanShot 2020-12-09 at 17 04 02](https://user-images.githubusercontent.com/6084427/101654375-bdb4e900-3a40-11eb-8226-fe1a9057faf8.gif)


## Dependencies / Requirements

<!-- If it's a new script command that requires some additional steps to make it work, please describe it here. E.g. requiring installation of another command line tool or requirement to specify username / API token / etc. -->

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)