### PR TITLE
Exclude newline when copying xkcdpass output

### DIFF
--- a/commands/communication/xkcdpass.sh
+++ b/commands/communication/xkcdpass.sh
@@ -18,6 +18,7 @@ if ! command -v xkcdpass &> /dev/null; then
 	exit 1;
 fi
 
-xkcdpass | pbcopy
+passphrase=$(xkcdpass)
+echo -n $passphrase | pbcopy
 
 echo "Copied passphrase"


### PR DESCRIPTION
## Description

<!-- Please write a short summary for this change. If it's a new script command, explain what it does. -->

Exclude newline when copying `xkcdpass` output.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Improvement of an existing script

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)