### PR TITLE
Add Script Commands: set-volume for Music and TV

### DIFF
--- a/commands/media/apple-music/apple-music-set-volume.applescript
+++ b/commands/media/apple-music/apple-music-set-volume.applescript
@@ -1,0 +1,19 @@
+#!/usr/bin/osascript
+
+# @raycast.title Volume
+# @raycast.author Caleb Stauffer
+# @raycast.authorURL https://github.com/crstauf
+# @raycast.description Set volume in Music.
+
+# @raycast.icon images/apple-music-logo.png
+# @raycast.mode silent
+# @raycast.packageName Music
+# @raycast.schemaVersion 1
+
+# @raycast.argument1 { "type": "text", "placeholder": "Level" }
+
+on run argv
+	tell application "Music"
+		set the sound volume to (item 1 of argv)
+	end tell
+end run

--- a/commands/media/apple-music/apple-music-set-volume.applescript
+++ b/commands/media/apple-music/apple-music-set-volume.applescript
@@ -1,6 +1,6 @@
 #!/usr/bin/osascript
 
-# @raycast.title Volume
+# @raycast.title Set Volume
 # @raycast.author Caleb Stauffer
 # @raycast.authorURL https://github.com/crstauf
 # @raycast.description Set volume in Music.

--- a/commands/media/apple-tv/apple-tv-set-volume.applescript
+++ b/commands/media/apple-tv/apple-tv-set-volume.applescript
@@ -1,0 +1,19 @@
+#!/usr/bin/osascript
+
+# @raycast.title Volume
+# @raycast.author Caleb Stauffer
+# @raycast.authorURL https://github.com/crstauf
+# @raycast.description Set volume in TV.
+
+# @raycast.icon images/apple-tv-logo.png
+# @raycast.mode silent
+# @raycast.packageName TV
+# @raycast.schemaVersion 1
+
+# @raycast.argument1 { "type": "text", "placeholder": "Level" }
+
+on run argv
+	tell application "TV"
+		set the sound volume to (item 1 of argv)
+	end tell
+end run

--- a/commands/media/apple-tv/apple-tv-set-volume.applescript
+++ b/commands/media/apple-tv/apple-tv-set-volume.applescript
@@ -1,6 +1,6 @@
 #!/usr/bin/osascript
 
-# @raycast.title Volume
+# @raycast.title Set Volume
 # @raycast.author Caleb Stauffer
 # @raycast.authorURL https://github.com/crstauf
 # @raycast.description Set volume in TV.


### PR DESCRIPTION
## Description

<!-- Please write a short summary for this change. If it's a new script command, explain what it does. -->

Music and TV have independent volume controls, so there should be script commands to control those. :wink:

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New script command

## Screenshot

<!-- If it's a new script command, please include a screenshot or a GIF of how it works. -->

<img width="768" alt="Screen Shot 2020-12-10 at 4 16 58 PM" src="https://user-images.githubusercontent.com/4573033/101830885-2cf31180-3b03-11eb-9c01-b1ef22f991cb.png">

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)