### PR TITLE
fix: wrong countdown condition

### DIFF
--- a/commands/dashboard/countdowns/countdown-to-date.template.sh
+++ b/commands/dashboard/countdowns/countdown-to-date.template.sh
@@ -40,7 +40,7 @@ REMAINING=$(($TIMESTAMP_EVENT - $TIMESTAMP_TODAY))
 DAYS_REMAINING=$(($REMAINING / 86400))
 HOURS_REMAINING=$(($REMAINING % 86400 / 3600))
 
-if [[  $HOURS_REMAINING > 0 ]]; then
+if [[ $DAYS_REMAINING > 0 || $HOURS_REMAINING > 0 ]]; then
     echo "There are $DAYS_REMAINING days and $HOURS_REMAINING hours left until your event."
 else
     echo "Your message\!"

--- a/commands/dashboard/countdowns/create-countdown.template.sh
+++ b/commands/dashboard/countdowns/create-countdown.template.sh
@@ -53,7 +53,7 @@ REMAINING=\$((\$TIMESTAMP_EVENT - \$TIMESTAMP_TODAY))\n\
 DAYS_REMAINING=\$((\$REMAINING / 86400))\n\
 HOURS_REMAINING=\$((\$REMAINING % 86400 / 3600))\n\
 \n\
-if [[  \$HOURS_REMAINING > 0 ]]; then\n\
+if [[ \$DAYS_REMAINING > 0 || \$HOURS_REMAINING > 0 ]]; then\n\
     echo \"There are \$DAYS_REMAINING days and \$HOURS_REMAINING hours left until ${1// /%20}.\"\n\
 else\n\
     echo \"Your message\!\"\n\


### PR DESCRIPTION
## Description

<!-- Please write a short summary for this change. If it's a new script command, explain what it does. -->

Fix the wrong `if` condition in countdown scripts

## Type of change

- [x] Bug fix

<!-- If it's a new script command that requires some additional steps to make it work, please describe it here. E.g. requiring installation of another command line tool or requirement to specify username / API token / etc. -->

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)