### PR TITLE
Created AppleScript to automate toggling greyscale

### DIFF
--- a/commands/system/toggle-greyscale.applescript
+++ b/commands/system/toggle-greyscale.applescript
@@ -1,0 +1,24 @@
+#!/usr/bin/osascript
+
+# @raycast.title Toggle Greyscale
+# @raycast.author Matthew Alp
+# @raycast.authorURL https://github.com/MattAlp
+# @raycast.description Toggle system greyscale through automation
+
+# @raycast.mode silent
+# Optional parameters:
+# @raycast.icon 🔘
+# @raycast.packageName System
+# @raycast.schemaVersion 1
+
+tell application "System Preferences"
+    activate
+    set the current pane to pane id "com.apple.preference.universalaccess"
+    delay 1 #needs time to open universal access
+    tell application "System Events" to tell process "System Preferences" to tell window "Accessibility"
+        select row 5 of table 1 of scroll area 1 #open display preferences
+        click radio button "Color Filters" of tab group 1 of group 1
+        click checkbox "Enable Color Filters" of tab group 1 of group 1
+    end tell
+end tell
+tell application "System Preferences" to quit


### PR DESCRIPTION
## Description

This script uses AppleScript automation to toggle the greyscale colour filter in accessibility settings.

## Type of change

- [x] New script command

## Screenshot

The greyscale colour change does not get picked up by software, but the automation flow is visible.

https://user-images.githubusercontent.com/19317416/103956822-4d6cb680-5117-11eb-89c0-9290e66884a8.mov


## Dependencies / Requirements

**N/A**

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)