### PR TITLE
Add multi-project Sentry unresolved issues script

### DIFF
--- a/commands/developer-utils/sentry/sentry-unresolved-issues-by-project.py
+++ b/commands/developer-utils/sentry/sentry-unresolved-issues-by-project.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+
+# How to use this script?
+# It's a template which needs further setup. Set an API token as
+# well as the Sentry organization.
+#
+# API: https://docs.sentry.io/api/events/list-a-projects-issues/
+
+
+# Parameters
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Sentry Unresolved Issues (By Project)
+# @raycast.mode fullOutput
+
+# Conditional parameters:
+# @raycast.refreshTime 1h
+
+# Optional parameters:
+# @raycast.packageName Sentry
+# @raycast.icon images/sentry.png
+# @raycast.iconDark images/sentry-dark.png
+# @raycast.argument1 { "type": "text", "placeholder": "Project" }
+
+# Documentation:
+# @raycast.author Thomas Paul Mann & Phil Salant
+# @raycast.authorURL https://github.com/thomaspaulmann
+# @raycast.description Show unresolved issues in the last 24 hours (by project) from Sentry.
+
+
+# Configuration
+
+# API token with `project:read` scope (https://sentry.io/settings/account/api/auth-tokens/)
+API_TOKEN = ""
+if not API_TOKEN:
+  print("No API token provided")
+  exit(1)
+
+# Slug of organization the issues belong to
+ORGANIZATION = ""
+if not ORGANIZATION:
+  print("No Sentry organization provided")
+  exit(1)
+
+# Main program
+
+import json, sys, urllib.request
+from datetime import datetime
+
+# Slug of project the issues belong to
+project = ""
+if len(sys.argv) > 1:
+  project = sys.argv[1]
+
+if not project:
+  print("No Sentry project provided")
+  exit(1)
+
+url = f"https://sentry.io/api/0/projects/{ORGANIZATION}/{project}/issues/?statsPeriod=24h&query=is:unresolved"
+request = urllib.request.Request(url)
+request.add_header("Authorization", f"Bearer {API_TOKEN}")
+
+try:
+  response = urllib.request.urlopen(request)
+except urllib.error.HTTPError as e:
+  print("Failed to get unresolved issues from Sentry")
+  exit(1)
+except urllib.error.URLError as e:
+  print("Error reason: ", e.reason)
+  print("Failed to reach Sentry")
+  exit(1)
+else:
+  data = response.read().decode("utf-8")
+  unresolved_issues = json.loads(data)
+  unresolved_issues_count = len(unresolved_issues)
+
+  if unresolved_issues_count == 0:
+    print("No unresolved issues in the last 24 hours.")
+  else:
+    issue_text = "issue" if unresolved_issues_count == 1 else "issues"
+    print(f"{unresolved_issues_count} unresolved {issue_text} in the last 24 hours:")
+
+    count = 1
+    for issue in unresolved_issues:
+      last_seen = datetime.strptime(issue['lastSeen'], "%Y-%m-%dT%H:%M:%S.%fZ")
+
+      print(f"  {count}. {issue['title']} ({last_seen.strftime('%b %d, %Y %I:%M %p')})")
+      print(f"     {issue['permalink']}\n")
+
+      count += 1

--- a/commands/developer-utils/sentry/sentry-unresolved-issues-by-project.template.py
+++ b/commands/developer-utils/sentry/sentry-unresolved-issues-by-project.template.py
@@ -12,7 +12,7 @@
 
 # Required parameters:
 # @raycast.schemaVersion 1
-# @raycast.title Sentry Unresolved Issues (By Project)
+# @raycast.title Unresolved Issues By Project
 # @raycast.mode fullOutput
 
 # Conditional parameters:

--- a/commands/developer-utils/sentry/sentry-unresolved-issues-by-project.template.py
+++ b/commands/developer-utils/sentry/sentry-unresolved-issues-by-project.template.py
@@ -25,7 +25,9 @@
 # @raycast.argument1 { "type": "text", "placeholder": "Project" }
 
 # Documentation:
-# @raycast.author Thomas Paul Mann & Phil Salant
+# @raycast.author Phil Salant
+# @raycast.authorURL https://github.com/PSalant726
+# @raycast.author Thomas Paul Mann
 # @raycast.authorURL https://github.com/thomaspaulmann
 # @raycast.description Show unresolved issues in the last 24 hours (by project) from Sentry.
 

--- a/commands/developer-utils/sentry/sentry-unresolved-issues-by-project.template.py
+++ b/commands/developer-utils/sentry/sentry-unresolved-issues-by-project.template.py
@@ -47,7 +47,6 @@ if not ORGANIZATION:
   exit(1)
 
 # Main program
-
 import json, sys, urllib.request
 from datetime import datetime as dt
 
@@ -73,8 +72,7 @@ except urllib.error.URLError as e:
   print("Error:", e.reason)
   exit(1)
 else:
-  data = response.read().decode("utf-8")
-  unresolved_issues = json.loads(data)
+  unresolved_issues = json.loads(response.read().decode("utf-8"))
   unresolved_issues_count = len(unresolved_issues)
 
   if unresolved_issues_count == 0:
@@ -83,11 +81,8 @@ else:
     issue_text = "issue" if unresolved_issues_count == 1 else "issues"
     print(f"{unresolved_issues_count} unresolved {issue_text} in the last 24 hours:")
 
-    count = 1
-    for issue in unresolved_issues:
+    for i, issue in enumerate(unresolved_issues, 1):
       last_seen = dt.strptime(issue['lastSeen'], "%Y-%m-%dT%H:%M:%S.%fZ")
 
-      print(f"  {count}. {issue['title']} ({last_seen.strftime('%b %d, %Y %I:%M %p')})")
+      print(f"  {i}. {issue['title']} ({last_seen.strftime('%b %d, %Y at %I:%M %p')})")
       print(f"     {issue['permalink']}\n")
-
-      count += 1

--- a/commands/developer-utils/sentry/sentry-unresolved-issues-by-project.template.py
+++ b/commands/developer-utils/sentry/sentry-unresolved-issues-by-project.template.py
@@ -51,10 +51,7 @@ if not ORGANIZATION:
 import json, sys, urllib.request
 from datetime import datetime as dt
 
-project = ""
-if len(sys.argv) > 1:
-  project = sys.argv[1]
-
+project = sys.argv[1]
 if not project:
   print("No Sentry project provided")
   exit(1)

--- a/commands/developer-utils/sentry/sentry-unresolved-issues-by-project.template.py
+++ b/commands/developer-utils/sentry/sentry-unresolved-issues-by-project.template.py
@@ -56,18 +56,21 @@ if not project:
   print("No Sentry project provided")
   exit(1)
 
-url = f"https://sentry.io/api/0/projects/{ORGANIZATION}/{project}/issues/?statsPeriod=24h&query=is:unresolved"
-request = urllib.request.Request(url)
-request.add_header("Authorization", f"Bearer {API_TOKEN}")
+request = urllib.request.Request(
+  method="GET",
+  url=f"https://sentry.io/api/0/projects/{ORGANIZATION}/{project}/issues/?statsPeriod=24h&query=is:unresolved",
+  headers={ "Authorization": f"Bearer {API_TOKEN}" }
+)
 
 try:
   response = urllib.request.urlopen(request)
 except urllib.error.HTTPError as e:
-  print("Failed to get unresolved issues from Sentry")
+  print("Failed to get unresolved issues from Sentry:")
+  print(e.code, e.reason)
   exit(1)
 except urllib.error.URLError as e:
-  print("Error reason: ", e.reason)
-  print("Failed to reach Sentry")
+  print("Failed to reach Sentry:")
+  print("Error:", e.reason)
   exit(1)
 else:
   data = response.read().decode("utf-8")

--- a/commands/developer-utils/sentry/sentry-unresolved-issues-by-project.template.py
+++ b/commands/developer-utils/sentry/sentry-unresolved-issues-by-project.template.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 
 # How to use this script?
-# It's a template which needs further setup. Set an API token as
+# It's a template which needs further setup. Duplicate the file,
+# remove `.template.` from the filename and set an API token as
 # well as the Sentry organization.
 #
 # API: https://docs.sentry.io/api/events/list-a-projects-issues/
@@ -46,9 +47,8 @@ if not ORGANIZATION:
 # Main program
 
 import json, sys, urllib.request
-from datetime import datetime
+from datetime import datetime as dt
 
-# Slug of project the issues belong to
 project = ""
 if len(sys.argv) > 1:
   project = sys.argv[1]
@@ -83,7 +83,7 @@ else:
 
     count = 1
     for issue in unresolved_issues:
-      last_seen = datetime.strptime(issue['lastSeen'], "%Y-%m-%dT%H:%M:%S.%fZ")
+      last_seen = dt.strptime(issue['lastSeen'], "%Y-%m-%dT%H:%M:%S.%fZ")
 
       print(f"  {count}. {issue['title']} ({last_seen.strftime('%b %d, %Y %I:%M %p')})")
       print(f"     {issue['permalink']}\n")


### PR DESCRIPTION
## Description

Adds a refactored version of [`sentry-unresolved-issues.template.py`](https://github.com/raycast/script-commands/blob/master/commands/developer-utils/sentry/sentry-unresolved-issues.template.py), which accepts a `Project` argument, and outputs all unresolved issues in the last 24h.

## Type of change
- [X] New script command
- [X] ~Improvement~ Refactoring of an existing script

## Screenshots

### Input
<img width="862" alt="Screen Shot 2021-01-18 at 4 22 05 PM" src="https://user-images.githubusercontent.com/18120121/104964236-06e64a00-59aa-11eb-8816-fa8ce279693d.png">

### Output (private details redacted)
<img width="862" alt="Screen Shot 2021-01-18 at 4 22 11 PM" src="https://user-images.githubusercontent.com/18120121/104964519-870caf80-59aa-11eb-99d9-91d4cdeb28c2.png">

## Dependencies / Requirements

None

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)