### PR TITLE
Add a script to visit a specific GitHub repo, pull request, or issue

### DIFF
--- a/commands/developer-utils/github/open-gh-repo-pr-or-issue.sh
+++ b/commands/developer-utils/github/open-gh-repo-pr-or-issue.sh
@@ -3,15 +3,14 @@
 # Required parameters:
 # @raycast.schemaVersion 1
 # @raycast.title Visit a Repository, Pull Request, or Issue
-# @raycast.mode compact
+# @raycast.mode silent
 #
 # Optional parameters:
 # @raycast.packageName GitHub
 # @raycast.icon images/github-logo.png
 # @raycast.iconDark images/github-logo-iconDark.png
 # @raycast.argument1 { "type": "text", "placeholder": "Organization/Repository" }
-# @raycast.argument2 { "type": "text", "placeholder": "Pull Request #", "optional": true }
-# @raycast.argument3 { "type": "text", "placeholder": "Issue #", "optional": true }
+# @raycast.argument2 { "type": "text", "placeholder": "Pull Request or Issue #", "optional": true }
 #
 # Documentation
 # @raycast.author Phil Salant
@@ -19,15 +18,8 @@
 # @raycast.description Open a repository, pull request, or issue on GitHub
 
 path=""
-if [[ -n "$2" && -n "$3" ]]; then
-  echo "Do not pass both a pull request and an issue."
-  exit 1
-elif [[ -n "$2" ]]; then
+if [ -n "$2" ]; then
   path="/pull/$2"
-elif [[ -n "$3" ]]; then
-  path="/issues/$3"
 fi
 
-echo "Opening $1$path on GitHub..."
 open "https://github.com/$1$path"
-exit 0

--- a/commands/developer-utils/github/open-gh-repo-pr-or-issue.sh
+++ b/commands/developer-utils/github/open-gh-repo-pr-or-issue.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title GitHub Repository PRs & Issues
+# @raycast.mode compact
+#
+# Optional parameters:
+# @raycast.packageName GitHub
+# @raycast.icon images/github-logo.png
+# @raycast.iconDark images/github-logo-iconDark.png
+# @raycast.argument1 { "type": "text", "placeholder": "Organization/Repository" }
+# @raycast.argument2 { "type": "text", "placeholder": "Pull Request #", "optional": true }
+# @raycast.argument3 { "type": "text", "placeholder": "Issue #", "optional": true }
+#
+# Documentation
+# @raycast.author Phil Salant
+# @raycast.authorURL https://github.com/PSalant726
+# @raycast.description Open a repository, pull request, or issue on GitHub
+
+pull_request=""
+issue=""
+
+if [[ -n "$2" && -n "$3" ]]; then
+  echo "Do not pass both a pull request and an issue."
+  exit 1
+elif [[ -n "$2" ]]; then
+  pull_request="/pull/$2"
+elif [[ -n "$3" ]]; then
+  issue="/issues/$3"
+fi
+
+echo "Opening $1$pull_request$issue on GitHub..."
+open "https://github.com/$1$pull_request$issue"
+exit 0

--- a/commands/developer-utils/github/open-gh-repo-pr-or-issue.sh
+++ b/commands/developer-utils/github/open-gh-repo-pr-or-issue.sh
@@ -18,18 +18,16 @@
 # @raycast.authorURL https://github.com/PSalant726
 # @raycast.description Open a repository, pull request, or issue on GitHub
 
-pull_request=""
-issue=""
-
+path=""
 if [[ -n "$2" && -n "$3" ]]; then
   echo "Do not pass both a pull request and an issue."
   exit 1
 elif [[ -n "$2" ]]; then
-  pull_request="/pull/$2"
+  path="/pull/$2"
 elif [[ -n "$3" ]]; then
-  issue="/issues/$3"
+  path="/issues/$3"
 fi
 
-echo "Opening $1$pull_request$issue on GitHub..."
-open "https://github.com/$1$pull_request$issue"
+echo "Opening $1$path on GitHub..."
+open "https://github.com/$1$path"
 exit 0

--- a/commands/developer-utils/github/open-gh-repo-pr-or-issue.sh
+++ b/commands/developer-utils/github/open-gh-repo-pr-or-issue.sh
@@ -2,7 +2,7 @@
 
 # Required parameters:
 # @raycast.schemaVersion 1
-# @raycast.title GitHub Repository PRs & Issues
+# @raycast.title Visit a Repository, Pull Request, or Issue
 # @raycast.mode compact
 #
 # Optional parameters:


### PR DESCRIPTION
## Description

Do you already know which GitHub repo you want to open, and don't need to use the GitHub extension to search for a repository? Better yet, do you already know the specific pull request and/or issue by number? Then use this script command!

## Type of change

- [x] New script command

## Screenshot

### Visit a repo directly
<img width="862" alt="Screen Shot 2021-01-23 at 6 09 30 PM" src="https://user-images.githubusercontent.com/18120121/105616615-595aa880-5da6-11eb-83d4-913607b51f23.png">

### Visit a PR directly
<img width="862" alt="Screen Shot 2021-01-23 at 6 09 52 PM" src="https://user-images.githubusercontent.com/18120121/105616621-65466a80-5da6-11eb-8b51-75e942880827.png">

### Visit an Issue directly
<img width="862" alt="Screen Shot 2021-01-23 at 6 10 02 PM" src="https://user-images.githubusercontent.com/18120121/105616629-70999600-5da6-11eb-8614-6aee14579668.png">

## Dependencies / Requirements

None

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)