### PR TITLE
Add script for audio output switch

### DIFF
--- a/commands/system/audio-output-switch.template.applescript
+++ b/commands/system/audio-output-switch.template.applescript
@@ -28,6 +28,8 @@ tell application "System Preferences"
 		end tell
 	end tell
 	
-do shell script "echo Audio switched to <Device Name>"
+	quit
 	
 end tell
+
+do shell script "echo Audio switched to <Device Name>"

--- a/commands/system/audio-output-switch.template.applescript
+++ b/commands/system/audio-output-switch.template.applescript
@@ -10,7 +10,7 @@
 # @raycast.mode silent
 
 # @raycast.packageName Audio
-# @raycast.icon ??
+# @raycast.icon 🔊
 
 # @raycast.author mmerle
 # @raycast.authorURL https://github.com/mmerle

--- a/commands/system/audio-output-switch.template.applescript
+++ b/commands/system/audio-output-switch.template.applescript
@@ -1,0 +1,33 @@
+#!/usr/bin/osascript
+
+# How to use this script?
+# It's a template which needs further setup. Duplicate the file,
+# remove `.template.` from the filename,
+# Replace all instances of <Device Name> with the name of your desired audio output device
+
+# @raycast.schemaVersion 1
+# @raycast.title Switch Audio to <Device Name>
+# @raycast.mode silent
+
+# @raycast.packageName Audio
+# @raycast.icon ??
+
+# @raycast.author mmerle
+# @raycast.authorURL https://github.com/mmerle
+# @raycast.description Switch audio output to desired device.
+
+set asrc to "<Device Name>"
+
+tell application "System Preferences"
+
+	reveal anchor "output" of pane id "com.apple.preference.sound"
+	
+	tell application "System Events"
+		tell process "System Preferences"
+			select (row 1 of table 1 of scroll area 1 of tab group 1 of window "Sound" whose value of text field 1 is asrc)
+		end tell
+	end tell
+	
+do shell script "echo Audio switched to <Device Name>"
+	
+end tell


### PR DESCRIPTION
## Description

Switches audio output to desired output device. Example below shows HomePod.

## Type of change

- [x] New script command

## Screenshot

![Screen Shot 2021-01-27 at 12 40 20 PM](https://user-images.githubusercontent.com/35971019/106031114-dc2c7d80-609c-11eb-8aa5-60488d60a76d.png)

## Dependencies / Requirements

Replace all instances of `<Device Name>` with the name of your desired audio output device

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)