### PR TITLE
Fix decimal date calculation

### DIFF
--- a/commands/dashboard/year-progress.sh
+++ b/commands/dashboard/year-progress.sh
@@ -44,7 +44,7 @@ else
   DAYS=365
 fi
 
-percentage=$((100 * $current_day / $DAYS))
+percentage=$((100 * 10#$current_day / $DAYS))
 
 filled_element_count=$(($BAR_LENGTH * $percentage / 100))
 blank_element_count=$(($BAR_LENGTH - $filled_element_count))


### PR DESCRIPTION
## Description

If day of the year returns number with prepended 0(zero) script can't
calculate progress with error: "Value too great for base" because
bash assumes it is octal number. 

## Type of change
- [x] Bug fix

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)