### PR TITLE
Update get external IP scripts to use ipify.org API instead of ifconfig.co

### DIFF
--- a/commands/developer-utils/ip/get-external-ip-v4.sh
+++ b/commands/developer-utils/ip/get-external-ip-v4.sh
@@ -13,5 +13,5 @@
 # Documentation:
 # @raycast.description Copies the external IPv4 to the clipboard.
 
-ip=$(curl -4 -s -m 5 https://ifconfig.co)
+ip=$(curl -4 -s -m 5 https://api.ipify.org)
 echo $ip

--- a/commands/developer-utils/ip/get-external-ip-v6.sh
+++ b/commands/developer-utils/ip/get-external-ip-v6.sh
@@ -13,5 +13,5 @@
 # Documentation:
 # @raycast.description Copies the external IPv6 to the clipboard.
 
-ip=$(curl -6 -s -m 5 https://ifconfig.co)
+ip=$(curl -6 -s -m 5 https://api64.ipify.org)
 echo $ip


### PR DESCRIPTION
A CAPTCHA prevents the script from working with ifconfig.co API.
Therefore, the script now uses the ipify.org API.