### PR TITLE
Use wikipedia.org as default

### DIFF
--- a/commands/web-searches/search-in-wikipedia.sh
+++ b/commands/web-searches/search-in-wikipedia.sh
@@ -10,6 +10,6 @@
 
 # Optional parameters:
 # @raycast.icon images/wikipedia.png
-# @raycast.argument1 { "type": "text", "placeholder": "关键词...", "percentEncoded": true }
+# @raycast.argument1 { "type": "text", "placeholder": "Search term...", "percentEncoded": true }
 
-open "https://zh.wikipedia.org/w/index.php?search=$1"
+open "https://wikipedia.org/w/index.php?search=$1"

--- a/commands/web-searches/search-in-wikipedia.sh
+++ b/commands/web-searches/search-in-wikipedia.sh
@@ -12,4 +12,6 @@
 # @raycast.icon images/wikipedia.png
 # @raycast.argument1 { "type": "text", "placeholder": "Search term...", "percentEncoded": true }
 
-open "https://wikipedia.org/w/index.php?search=$1"
+domain="zh"
+
+open "https://$domain.wikipedia.org/w/index.php?search=$1"


### PR DESCRIPTION
## Description

Changes wikipedia search script to use wikipedia.org instead of chinese by default (zh)

## Type of change

- [x] Improvement of an existing script

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)