### PR TITLE
Fix bug 233. Urlencode the base64 encoded code prior to generating url

### DIFF
--- a/commands/developer-utils/create-image-from-code.sh
+++ b/commands/developer-utils/create-image-from-code.sh
@@ -34,5 +34,7 @@ else
 fi
 
 CODE=$(pbpaste | base64)
+# Urlencode any + symbols in the base64 encoded string
+CODE=${CODE//+/%2B}
 
 open "https://ray.so/?colors=$COLORS&background=$BACKGROUND&darkMode=$DARK_MODE&padding=$PADDING&title=$TITLE&code=$CODE"


### PR DESCRIPTION
## Description

Update script `create-image-from-code.sh` to urlencode the base64 encoded code query param prior to generating URL to ray.so. Fixes issue #233. 

## Type of change

- [X] Bug fix
- [X] Improvement of an existing script

## Screenshot

N/A

## Dependencies / Requirements

N/A

## Checklist

- [X] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)