### PR TITLE
Add error info

### DIFF
--- a/commands/browsing/go-to-outine.sh
+++ b/commands/browsing/go-to-outine.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # @raycast.author Ronan Rodrigo Nunes
-# @raycast.authorURL ronanrodrigo.dev
+# @raycast.authorURL https://ronanrodrigo.dev
 # @raycast.packageName Browsing
 # @raycast.schemaVersion 1
 # @raycast.title Go to Outline

--- a/commands/developer-utils/error-info.sh
+++ b/commands/developer-utils/error-info.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Dependency: requires mint and errorinfo
+# Instal via mint Homebrew and errorinfo via Mint: `brew install mint && mint install errorinfo`
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Error Info
+# @raycast.mode fullOutput
+# @raycast.packageName Developer Utilities
+
+# Optional parameters:
+# @raycast.icon ℹ️
+# @raycast.argument1 { "type": "text", "placeholder": "Error term" }
+
+# @Documentation:
+# @raycast.description Get info about Apple API errors
+# @raycast.author Ronan Rodrigo Nunes
+# @raycast.authorURL https://ronanrodrigo.dev
+
+errorinfo $1

--- a/commands/developer-utils/whois.sh
+++ b/commands/developer-utils/whois.sh
@@ -7,7 +7,7 @@
 # @raycast.author Caleb Stauffer
 # @raycast.authorURL https://github.com/crstauf
 # @raycast.author Ronan Rodrigo Nunes
-# @raycast.authorURL ronanrodrigo.dev
+# @raycast.authorURL https://ronanrodrigo.dev
 
 # @raycast.description Whois of URL.
 


### PR DESCRIPTION
## Description
I created a CLI to search about Apple API errors called [ErrorInfo](https://github.com/ronanrodrigo/ErrorInfo) and now I am adding it to the Raycast.

## Type of change
- [x] New script command

## Screenshot
![Screen Shot 2021-02-19 at 18 56 03](https://user-images.githubusercontent.com/421758/108566353-0f051280-72e5-11eb-8f2d-b2600b656677.png)

## Dependencies / Requirements
- brew
- mint
- errorinfo

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)