### PR TITLE
Colorized command output

### DIFF
--- a/commands/developer-utils/sentry/sentry-unresolved-issues-by-project.template.py
+++ b/commands/developer-utils/sentry/sentry-unresolved-issues-by-project.template.py
@@ -50,9 +50,25 @@ if not ORGANIZATION:
 import json, sys, urllib.request
 from datetime import datetime as dt
 
+colors = {
+  'ok': '\033[92m',
+  'error': '\033[91m',
+  'end': '\033[0m',
+  'warn': '\033[93m',
+}
+
+def error(message):
+  return f"{colors['error']}{message}{colors['end']}"
+
+def ok(message):
+  return f"{colors['ok']}{message}{colors['end']}"
+
+def warn(message):
+  return f"{colors['warn']}{message}{colors['end']}"
+
 project = sys.argv[1]
 if not project:
-  print("No Sentry project provided")
+  print(error("No Sentry project provided"))
   exit(1)
 
 request = urllib.request.Request(
@@ -64,22 +80,20 @@ request = urllib.request.Request(
 try:
   response = urllib.request.urlopen(request)
 except urllib.error.HTTPError as e:
-  print("Failed to get unresolved issues from Sentry:")
-  print(e.code, e.reason)
+  print(f"{error('Failed to get unresolved issues from Sentry:')} {e.code} {e.reason}")
   exit(1)
 except urllib.error.URLError as e:
-  print("Failed to reach Sentry:")
-  print("Error:", e.reason)
+  print(f"{error('Failed to reach Sentry:')} {e.reason}")
   exit(1)
 else:
   unresolved_issues = json.loads(response.read().decode("utf-8"))
   unresolved_issues_count = len(unresolved_issues)
 
   if unresolved_issues_count == 0:
-    print("No unresolved issues in the last 24 hours.")
+    print(ok("No unresolved issues in the last 24 hours."))
   else:
     issue_text = "issue" if unresolved_issues_count == 1 else "issues"
-    print(f"{unresolved_issues_count} unresolved {issue_text} in the last 24 hours:")
+    print(error(f"{unresolved_issues_count} unresolved {issue_text} in the last 24 hours:\n"))
 
     for i, issue in enumerate(unresolved_issues, 1):
       last_seen = dt.strptime(issue['lastSeen'], "%Y-%m-%dT%H:%M:%S.%fZ")

--- a/commands/developer-utils/sentry/sentry-unresolved-issues-by-project.template.py
+++ b/commands/developer-utils/sentry/sentry-unresolved-issues-by-project.template.py
@@ -31,19 +31,22 @@
 # @raycast.authorURL https://github.com/thomaspaulmann
 # @raycast.description Show unresolved issues in the last 24 hours (by project) from Sentry.
 
-
-# Configuration
+#########################
+##### Configuration #####
+#########################
 
 # API token with `project:read` scope (https://sentry.io/settings/account/api/auth-tokens/)
 API_TOKEN = ""
-if not API_TOKEN:
-  print("No API token provided")
-  exit(1)
 
 # Slug of organization the issues belong to
 ORGANIZATION = ""
+
+if not API_TOKEN:
+  print(error("No API token provided"))
+  exit(1)
+
 if not ORGANIZATION:
-  print("No Sentry organization provided")
+  print(error("No Sentry organization provided"))
   exit(1)
 
 # Main program

--- a/commands/developer-utils/sentry/sentry-unresolved-issues-by-project.template.py
+++ b/commands/developer-utils/sentry/sentry-unresolved-issues-by-project.template.py
@@ -99,7 +99,8 @@ else:
     print(error(f"{unresolved_issues_count} unresolved {issue_text} in the last 24 hours:\n"))
 
     for i, issue in enumerate(unresolved_issues, 1):
-      last_seen = dt.strptime(issue['lastSeen'], "%Y-%m-%dT%H:%M:%S.%fZ")
+      last_seen = dt.strptime(issue['lastSeen'], "%Y-%m-%dT%H:%M:%S.%fZ").strftime('%b %d, %Y at %I:%M %p')
 
-      print(f"  {i}. {issue['title']} ({last_seen.strftime('%b %d, %Y at %I:%M %p')})")
-      print(f"     {issue['permalink']}\n")
+      print(f"{i}. {warn(issue['title'])}")
+      print(f"   Last seen {last_seen}.")
+      print(f"   {issue['permalink']}\n")

--- a/commands/password-managers/bitwarden/search-vault-items.sh
+++ b/commands/password-managers/bitwarden/search-vault-items.sh
@@ -56,4 +56,4 @@ if [[ -n $2 && $2 == "y" ]]; then
 fi
 
 output_format="{ name, username: .login.username, $password uris: [.login.uris[]?.uri], lastUpdated: .revisionDate, notes $fields }"
-bw list items $session_args --search "$1" | jq ".[] | $output_format"
+bw list items $session_args --search "$1" | jq --color-output "map($output_format)"


### PR DESCRIPTION
## Description

Colorizes output for some `fullOutput` mode commands that I have contributed to this repo (`sentry/sentry-unresolved-issues-by-project` and `bitwarden/search-vault-items`).

## Type of change

- [x] Improvement of an existing script

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)