### PR TITLE
Add a date-to-weekday conversion script

### DIFF
--- a/commands/conversions/what-day-is.py
+++ b/commands/conversions/what-day-is.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+
+# Parameters
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title What Day Is...
+# @raycast.mode silent
+
+# Optional parameters:
+# @raycast.packageName Conversions
+# @raycast.icon 📅
+# @raycast.argument1 { "type": "text", "placeholder": "Date (YYYY-MM-DD)" }
+
+
+# Documentation:
+# @raycast.author Phil Salant
+# @raycast.authorURL https://github.com/PSalant726
+# @raycast.description Return the day of the week on which a particular date falls.
+
+import sys
+from datetime import datetime as dt
+
+print(dt.fromisoformat(sys.argv[1]).strftime("%A"))


### PR DESCRIPTION
## Description

Adds a script command to determine the day of the week on which a particular `YYYY-MM-DD` string fell/will fall. This was requested in the [Slack community](https://raycastcommunity.slack.com/archives/C01AC2X0GMN/p1613856204003100).

## Type of change

- [x] New script command

## Screenshot

<img width="862" alt="Screen Shot 2021-02-20 at 7 39 46 PM" src="https://user-images.githubusercontent.com/18120121/108612115-670a4a80-73b3-11eb-8fe0-71ed689bbc72.png">

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)