### PR TITLE
Update Script Commands to use percentEncoded key

### DIFF
--- a/commands/communication/slack/set-slack-DND-status.sh
+++ b/commands/communication/slack/set-slack-DND-status.sh
@@ -12,7 +12,7 @@
 
 # Optional parameters:
 # @raycast.packageName Slack
-# @raycast.argument1 { "type": "text", "placeholder": "number of minutes" }
+# @raycast.argument1 { "type": "text", "placeholder": "number of minutes", "percentEncoded": true}
 # @raycast.icon images/slack-logo.png
 
 # Documentation:
@@ -31,7 +31,7 @@
 API_TOKEN="XXXXXX"
 
 # Minutes until the the status will expire
-STATUS_EXPIRATION_IN_MINUTES="${1// /%20}"
+STATUS_EXPIRATION_IN_MINUTES="${1}"
 
 
 # Main program

--- a/commands/dashboard/countdowns/create-countdown.template.sh
+++ b/commands/dashboard/countdowns/create-countdown.template.sh
@@ -17,8 +17,8 @@
 
 # Optional parameters:
 # @raycast.icon ⏱
-# @raycast.argument1 { "type": "text", "placeholder": "Event Name" }
-# @raycast.argument2 { "type": "text", "placeholder": "Date (yyyy-mm-dd)" }
+# @raycast.argument1 { "type": "text", "placeholder": "Event Name", "percentEncoded": true }
+# @raycast.argument2 { "type": "text", "placeholder": "Date (yyyy-mm-dd)", "percentEncoded": true }
 
 # Documentation:
 # @raycast.author Valentin Chrétien
@@ -37,16 +37,16 @@ SCRIPT="#!/bin/bash\n\
 \n\
 # Required parameters:\n\
 # $RAYCAST.schemaVersion 1\n\
-# $RAYCAST.title ${1// /%20} Countdown\n\
+# $RAYCAST.title ${1} Countdown\n\
 # $RAYCAST.mode inline\n\
 \n\
 # Optional parameters:\n\
 # $RAYCAST.icon ⏱\n\
-# $RAYCAST.description See how many days/hours until ${1// /%20}.\n\
+# $RAYCAST.description See how many days/hours until ${1}.\n\
 # $RAYCAST.refreshTime 10m\n\
 \n\
 TIMESTAMP_TODAY=\`gdate +%s\`\n\
-TIMESTAMP_EVENT=\`gdate  -d \"${2// /%20}T00:00:00+00:00\" +%s\`\n\
+TIMESTAMP_EVENT=\`gdate  -d \"${2}T00:00:00+00:00\" +%s\`\n\
 \n\
 REMAINING=\$((\$TIMESTAMP_EVENT - \$TIMESTAMP_TODAY))\n\
 \n\
@@ -54,13 +54,13 @@ DAYS_REMAINING=\$((\$REMAINING / 86400))\n\
 HOURS_REMAINING=\$((\$REMAINING % 86400 / 3600))\n\
 \n\
 if [[ \$DAYS_REMAINING > 0 || \$HOURS_REMAINING > 0 ]]; then\n\
-    echo \"There are \$DAYS_REMAINING days and \$HOURS_REMAINING hours left until ${1// /%20}.\"\n\
+    echo \"There are \$DAYS_REMAINING days and \$HOURS_REMAINING hours left until ${1}.\"\n\
 else\n\
     echo \"Your message\!\"\n\
 fi"
 
-echo -e $SCRIPT > "$DIRECTORY_SCRIPT_PATH/countdown-${1// /%20}.sh"
+echo -e $SCRIPT > "$DIRECTORY_SCRIPT_PATH/countdown-${1}.sh"
 
-chmod +x "$DIRECTORY_SCRIPT_PATH/countdown-${1// /%20}.sh"
+chmod +x "$DIRECTORY_SCRIPT_PATH/countdown-${1}.sh"
 
 echo Countdown created! ✅

--- a/commands/web-searches/bundlephobia.sh
+++ b/commands/web-searches/bundlephobia.sh
@@ -10,6 +10,6 @@
 # Optional parameters:
 # @raycast.icon 📦
 # @raycast.packageName Web Searches
-# @raycast.argument1 { "type": "text", "placeholder": "package name" }
+# @raycast.argument1 { "type": "text", "placeholder": "package name", "percentEncoded": true }
 
-open "https://bundlephobia.com/result?p=${1// /%20}"
+open "https://bundlephobia.com/result?p=${1}"

--- a/commands/web-searches/caniuse.sh
+++ b/commands/web-searches/caniuse.sh
@@ -10,6 +10,6 @@
 # Optional parameters:
 # @raycast.icon ❓
 # @raycast.packageName Web searches
-# @raycast.argument1 { "type": "text", "placeholder": "feature" }
+# @raycast.argument1 { "type": "text", "placeholder": "feature", "percentEncoded": true }
 
-open "https://caniuse.com/#search=${1// /%20}"
+open "https://caniuse.com/#search=${1}"

--- a/commands/web-searches/crunchbase.sh
+++ b/commands/web-searches/crunchbase.sh
@@ -8,6 +8,6 @@
 
 # Optional parameters:
 # @raycast.icon images/crunchbase.png
-# @raycast.argument1 { "type": "text", "placeholder": "query" }
+# @raycast.argument1 { "type": "text", "placeholder": "query", "percentEncoded": true }
 
-open "https://www.crunchbase.com/textsearch?q=${1// /%20}"
+open "https://www.crunchbase.com/textsearch?q=${1}"

--- a/commands/web-searches/ecosia.sh
+++ b/commands/web-searches/ecosia.sh
@@ -8,11 +8,11 @@
 
 # Optional parameters:
 # @raycast.icon images/ecosia.png
-# @raycast.argument1 { "type": "text", "placeholder": "query" }
+# @raycast.argument1 { "type": "text", "placeholder": "query", "percentEncoded": true }
 
 # Documentation:
 # @raycast.author Sasivarnan R
 # @raycast.authorURL https://github.com/sasivarnan
 
 
-open "https://www.ecosia.org/search?q=${1// /%20}"
+open "https://www.ecosia.org/search?q=${1}"

--- a/commands/web-searches/figma.sh
+++ b/commands/web-searches/figma.sh
@@ -8,7 +8,7 @@
 
 # Optional parameters:
 # @raycast.icon images/figma.png
-# @raycast.argument1 { "type": "text", "placeholder": "query" }
+# @raycast.argument1 { "type": "text", "placeholder": "query", "percentEncoded": true }
 
 # Documentation:
 # @raycast.description Search files in Figma
@@ -23,4 +23,4 @@
 # 3. The current URL should now have an 18-digit id, that's your team_id. If you're using a personal workspace, leave the below variable blank.
 TEAM_ID=""
 
-open "https://www.figma.com/files/$TEAM_ID/search?model_type=files&q=${1// /%20}"
+open "https://www.figma.com/files/$TEAM_ID/search?model_type=files&q=${1}"

--- a/commands/web-searches/giphy.sh
+++ b/commands/web-searches/giphy.sh
@@ -10,6 +10,6 @@
 # Optional parameters:
 # @raycast.icon images/giphy.png
 # @raycast.packageName Web searches
-# @raycast.argument1 { "type": "text", "placeholder": "search" }
+# @raycast.argument1 { "type": "text", "placeholder": "search", "percentEncoded": true }
 
-open "https://giphy.com/search/${1// /%20}"
+open "https://giphy.com/search/${1}"

--- a/commands/web-searches/grep-app-search.sh
+++ b/commands/web-searches/grep-app-search.sh
@@ -8,6 +8,6 @@
 
 # Optional parameters:
 # @raycast.icon https://grep.app/favicon.ico
-# @raycast.argument1 { "type": "text", "placeholder": "query" }
+# @raycast.argument1 { "type": "text", "placeholder": "query", "percentEncoded": true }
 
-open "https://grep.app/search?q=${1// /%20}"
+open "https://grep.app/search?q=${1}"

--- a/commands/web-searches/mdn.sh
+++ b/commands/web-searches/mdn.sh
@@ -9,12 +9,12 @@
 # @raycast.packageName Web Searches
 # @raycast.icon images/mdn_light.png
 # @raycast.iconDark images/mdn_dark.png
-# @raycast.argument1 { "type": "text", "placeholder": "js, css, html", "optional": true}
-# @raycast.argument2 { "type": "text", "placeholder": "query" }
+# @raycast.argument1 { "type": "text", "placeholder": "js, css, html", "optional": true, "percentEncoded": true }
+# @raycast.argument2 { "type": "text", "placeholder": "query", "percentEncoded": true }
 #
 # Documentation:
 # @raycast.author Jesse Traynham
 # @raycast.authorURL https://github.com/traynham
 # @raycast.description Search in MDN (Mozilla) Docs by topic
 
-open "https://developer.mozilla.org/search?topic=${1// /%20}&q=${2// /%20}"
+open "https://developer.mozilla.org/search?topic=${1}&q=${2}"

--- a/commands/web-searches/mozilla-developer-network.sh
+++ b/commands/web-searches/mozilla-developer-network.sh
@@ -10,6 +10,6 @@
 
 # Optional parameters:
 # @raycast.icon images/mozilla-developer-network.png
-# @raycast.argument1 { "type": "text", "placeholder": "query" }
+# @raycast.argument1 { "type": "text", "placeholder": "query", "percentEncoded": true }
 
-open "https://developer.mozilla.org/search?q=${1// /%20}"
+open "https://developer.mozilla.org/search?q=${1}"

--- a/commands/web-searches/njt.sh
+++ b/commands/web-searches/njt.sh
@@ -10,6 +10,6 @@
 # Optional parameters:
 # @raycast.icon 🐸
 # @raycast.packageName Web Searches
-# @raycast.argument1 { "type": "text", "placeholder": "package-name [destination]" }
+# @raycast.argument1 { "type": "text", "placeholder": "package-name [destination]", "percentEncoded": true }
 
-open "https://njt.now.sh/jump?from=raycast&to=${1// /%20}"
+open "https://njt.now.sh/jump?from=raycast&to=${1}"

--- a/commands/web-searches/npmjs.sh
+++ b/commands/web-searches/npmjs.sh
@@ -8,6 +8,6 @@
 
 # Optional parameters:
 # @raycast.icon images/npmjs.png
-# @raycast.argument1 { "type": "text", "placeholder": "package name" }
+# @raycast.argument1 { "type": "text", "placeholder": "package name", "percentEncoded": true }
 
-open "https://www.npmjs.com/search?q=${1// /%20}"
+open "https://www.npmjs.com/search?q=${1}"

--- a/commands/web-searches/npms.sh
+++ b/commands/web-searches/npms.sh
@@ -10,6 +10,6 @@
 # Optional parameters:
 # @raycast.icon images/npms.png
 # @raycast.packageName Web Searches
-# @raycast.argument1 { "type": "text", "placeholder": "package name" }
+# @raycast.argument1 { "type": "text", "placeholder": "package name", "percentEncoded": true }
 
-open "https://npms.io/search?q=${1// /%20}"
+open "https://npms.io/search?q=${1}"

--- a/commands/web-searches/repo.sh
+++ b/commands/web-searches/repo.sh
@@ -10,6 +10,6 @@
 # Optional parameters:
 # @raycast.icon 📦
 # @raycast.packageName Web Searches
-# @raycast.argument1 { "type": "text", "placeholder": "package name" }
+# @raycast.argument1 { "type": "text", "placeholder": "package name", "percentEncoded": true }
 
-open "http://ghub.io/${1// /%20}"
+open "http://ghub.io/${1}"

--- a/commands/web-searches/search-cdnjs.sh
+++ b/commands/web-searches/search-cdnjs.sh
@@ -10,6 +10,6 @@
 # @raycast.packageName Web Searches
 # @raycast.schemaVersion 1
 
-# @raycast.argument1 { "type": "text", "placeholder": "Library" }
+# @raycast.argument1 { "type": "text", "placeholder": "Library", "percentEncoded": true }
 
-open "https://cdnjs.com/libraries?q=${1// /%20}"
+open "https://cdnjs.com/libraries?q=${1}"

--- a/commands/web-searches/search-github.sh
+++ b/commands/web-searches/search-github.sh
@@ -11,6 +11,6 @@
 # @raycast.packageName Web Searches
 # @raycast.schemaVersion 1
 
-# @raycast.argument1 { "type": "text", "placeholder": "Query" }
+# @raycast.argument1 { "type": "text", "placeholder": "Query", "percentEncoded": true }
 
-open "https://github.com/search?q=${1// /%20}"
+open "https://github.com/search?q=${1}"

--- a/commands/web-searches/search-netflix.sh
+++ b/commands/web-searches/search-netflix.sh
@@ -10,6 +10,6 @@
 # @raycast.packageName Web Searches
 # @raycast.schemaVersion 1
 
-# @raycast.argument1 { "type": "text", "placeholder": "Title" }
+# @raycast.argument1 { "type": "text", "placeholder": "Title", "percentEncoded": true }
 
-open "https://www.netflix.com/search?q=${1// /%20}"
+open "https://www.netflix.com/search?q=${1}"

--- a/commands/web-searches/search-php-docs.sh
+++ b/commands/web-searches/search-php-docs.sh
@@ -11,6 +11,6 @@
 # @raycast.packageName Web Searches
 # @raycast.schemaVersion 1
 
-# @raycast.argument1 { "type": "text", "placeholder": "Query" }
+# @raycast.argument1 { "type": "text", "placeholder": "Query", "percentEncoded": true }
 
-open "https://www.php.net/manual-lookup.php?pattern=${1// /%20}&scope=quickref"
+open "https://www.php.net/manual-lookup.php?pattern=${1}&scope=quickref"

--- a/commands/web-searches/search-wpengine-installs.sh
+++ b/commands/web-searches/search-wpengine-installs.sh
@@ -10,6 +10,6 @@
 # @raycast.packageName Web Searches
 # @raycast.schemaVersion 1
 
-# @raycast.argument1 { "type": "text", "placeholder": "Query" }
+# @raycast.argument1 { "type": "text", "placeholder": "Query", "percentEncoded": true }
 
-open "https://my.wpengine.com/omni_search?q=${1// /%20}"
+open "https://my.wpengine.com/omni_search?q=${1}"

--- a/commands/web-searches/twitter-search.sh
+++ b/commands/web-searches/twitter-search.sh
@@ -8,6 +8,6 @@
 
 # Optional parameters:
 # @raycast.icon images/twitter.png
-# @raycast.argument1 { "type": "text", "placeholder": "query" }
+# @raycast.argument1 { "type": "text", "placeholder": "query", "percentEncoded": true }
 
-open "https://twitter.com/search?q=${1// /%20}&src=typed_query"
+open "https://twitter.com/search?q=${1}&src=typed_query"

--- a/commands/web-searches/unfurl.sh
+++ b/commands/web-searches/unfurl.sh
@@ -10,6 +10,6 @@
 # Optional parameters:
 # @raycast.icon 🔗
 # @raycast.packageName Web Searches
-# @raycast.argument1 { "type": "text", "placeholder": "url" }
+# @raycast.argument1 { "type": "text", "placeholder": "url", "percentEncoded": true }
 
-open "https://unfurler.com/?url=${1// /%20}"
+open "https://unfurler.com/?url=${1}"

--- a/commands/web-searches/wayback-machine.sh
+++ b/commands/web-searches/wayback-machine.sh
@@ -10,6 +10,6 @@
 # Optional parameters:
 # @raycast.icon images/ia-logo.jpg
 # @raycast.packageName Web Searches
-# @raycast.argument1 { "type": "text", "placeholder": "url" }
+# @raycast.argument1 { "type": "text", "placeholder": "url", "percentEncoded": true }
 
-open "https://web.archive.org/web/*/${1// /%20}"
+open "https://web.archive.org/web/*/${1}"

--- a/commands/web-searches/wordpress/search-wordpress-docs.sh
+++ b/commands/web-searches/wordpress/search-wordpress-docs.sh
@@ -11,6 +11,6 @@
 # @raycast.packageName WordPress
 # @raycast.schemaVersion 1
 
-# @raycast.argument1 { "type": "text", "placeholder": "Query" }
+# @raycast.argument1 { "type": "text", "placeholder": "Query", "percentEncoded": true }
 
-open "https://wordpress.org/search/${1// /%20}?in=developer_documentation"
+open "https://wordpress.org/search/${1}?in=developer_documentation"

--- a/commands/web-searches/wordpress/wordpress-classes-reference.sh
+++ b/commands/web-searches/wordpress/wordpress-classes-reference.sh
@@ -11,6 +11,6 @@
 # @raycast.packageName WordPress
 # @raycast.schemaVersion 1
 
-# @raycast.argument1 { "type": "text", "placeholder": "Class name" }
+# @raycast.argument1 { "type": "text", "placeholder": "Class name", "percentEncoded": true }
 
-open "https://developer.wordpress.org/reference/classes/${1// /%20}/"
+open "https://developer.wordpress.org/reference/classes/${1}/"

--- a/commands/web-searches/wordpress/wordpress-functions-reference.sh
+++ b/commands/web-searches/wordpress/wordpress-functions-reference.sh
@@ -11,6 +11,6 @@
 # @raycast.packageName WordPress
 # @raycast.schemaVersion 1
 
-# @raycast.argument1 { "type": "text", "placeholder": "Function name" }
+# @raycast.argument1 { "type": "text", "placeholder": "Function name", "percentEncoded": true }
 
-open "https://developer.wordpress.org/reference/functions/${1// /%20}/"
+open "https://developer.wordpress.org/reference/functions/${1}/"

--- a/commands/web-searches/wordpress/wordpress-hooks-reference.sh
+++ b/commands/web-searches/wordpress/wordpress-hooks-reference.sh
@@ -11,6 +11,6 @@
 # @raycast.packageName WordPress
 # @raycast.schemaVersion 1
 
-# @raycast.argument1 { "type": "text", "placeholder": "Hook name" }
+# @raycast.argument1 { "type": "text", "placeholder": "Hook name", "percentEncoded": true }
 
-open "https://developer.wordpress.org/reference/hooks/${1// /%20}/"
+open "https://developer.wordpress.org/reference/hooks/${1}/"


### PR DESCRIPTION
## Description

A quick update in the current base of Script Commands to use the argument key "percentEncoded" instead of the manual space replacement.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] New script command
- [ ] Bug fix
- [x] Improvement of an existing script
- [ ] Documentation update
- [ ] Toolkit change
- [ ] Other (Specify)

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)