### PR TITLE
Add badges to Awesome Script Command README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,19 @@
 <div align="center">
+  <a href="https://github.com/raycast/script-commands">
+    <img alt="GitHub contributors" src="https://img.shields.io/badge/dynamic/json?style=for-the-badge&color=red&label=Script%20Commands&query=$.totalScriptCommands&url=https:%2F%2Fraw.githubusercontent.com%2Fraycast%2Fscript-commands%2Fmaster%2Fcommands%2Fextensions.json&logo=data:image%2Fpng%3Bbase64,iVBORw0KGgoAAAANSUhEUgAAAFgAAABYCAIAAAD%2B96djAAAIC0lEQVR4nOybW2zb1hmADynqLsuWRFLOBVmTpqkVy5LlpkgfDGRdnSvcdSiKIUWHosO8lwDtw4Bge1pRYMAw9KXAgAxYMiTNGjRZt%2B5plxQIkCzpNjduZMmJnMRpt7WR7NgSJYqULFISNUQ8pikpKVLpkOwDP%2BQhUajj40%2F%2Ff3j%2Bn0fEY1sfByYA4EZP4JuCKQJiioCYIiCmCIgpAmKKgJgiIKYIiCkCYoqAmCIgpgiIKQJiioCYIiDGi9jidIQ8bqNnYbSIkNv9h7HY%2B7HRXf39xs7ESBFbnc5To5Gg3d5vtf4uMhLu8xg4GSNF7BroJ202%2Be9eK3EmNvr0gGFxYRnw%2BY362SmeL1Rrzwb8AMMAAHYc30%2BSl3JMtlrVfzJGigAAJDguXRH2kQHowmJ5Phi8kmeWRVHnmegt4gmXa7vLlRYE5ZUUz%2BertT0BPwZd4JNBejpfWFJdowO6itjssJ8bix3euGGGZdOV9d8zwXFtOXKQoi4yuayoX47oJ2Kzw%2FHuaHSz00ng%2BH6K%2BpjJ31PFf4Lj%2BHp93O9T4mKCJC8zTE6v9UI%2FEc8M9B%2FeuNGy9plPBulrrXERLxbvVip7SVJ24SGIFwaDuuWIfiI%2BK68u8KVDNIUpLmi6LUfm%2BVJnjuizduq6RnxWLmcqwgQZkF0QOH6Aoq51rBeda%2BelnObrhbYiQm73bt%2FAQqmsvJLi%2BYVSaS9Fyjlia8bFbLH4ZaWiXJPgOLWvtdgpZrTMEQ1FbHU634tFX9wwmCxy%2F11dBQAMEMSugX6x0ahJjRFvn3wZgeOHaGpREAI22xanU%2F7D1%2Bsei2W7GxZjDovlgMY5gml0LCDkcZ%2BKRmi7HQAgStKRuRsXcrlxv%2B%2F3o9GuxyzWalPJuasFFulMIVrVGttcrsBaHWHD8Z9sewzreUwvQZwYCYfcmtTsWon4y%2FLKVGJOlCQAwE2OfyWeaKAY1mu1nh2LaVGnalh9XmSYI3M3Uhz3cny2UKuhGlauU2NeL6oBZVCK2Oyw7yNJ9SsXcrnJq58itCDjJYhT0cgQ0r4WMhHyDvrX4Z37qRYXSDJCZjpfkBpwPK%2BVOBmN7HC7UA2ORsQTLtefnoptc7lsOH4sPPzShkEkw7ZxbnHx6PxNxcWg3f7BU2OocgSNCJ%2FV6iUIOCKG%2FWroyYOtcYGKD5fuvXX7DlDiopkjSNZONCI%2BYdnXEklubS3AMeyd4Z0auTidTr95%2B446R87ERnvvgyNbI6YL7A%2FiCcWFDcdf3rQR1eBtnE6nfzp%2FS1LFRe998O5FbHU6v9%2B6FiQ57sfJuUq93suEHpE%2FLi39YmE9R3rvg3cpIuRxnx0b%2FeXQk69u2qR%2BfbpwP0d41PdLGWUZkjl59wE50nUfvJuia4vDcSY2GrTbMQx7NuBPV4QUzyv%2Fm64I11h2kqYzgvDnpXstb3Q6Xxzs%2FobyzMBAosh90VqnouqDdxMRbovFga%2B9EcPeDj0gLqY0yBGHxXI8Et7d%2BpmfTqePzt9ScsSK457WwHlEuomIbLU6w7IHaMou68CwPQF%2FoVpLcJxyzZeVyr8LbLnVRY8R8bBejtIHFyTp9RupK%2Fl8FyN32Y%2FICMIVhpmkabsFb6q4nyN8vR4vFpVryh0R0bsIpZfT2QdnxOq76fQ%2FmG4s9NSYWRbFT1l2P0XaLRbQlDHu992tVOb50sPegkSEHBedffAkx6nbXF%2BXnvYRV1n2cHy2qNpHvR0aalsvEPL35RW5rgcA9BHEe7HobnTPSnvdUM3zpVfis8Xquou3dmzXyMVH2ewb11PK%2FbKvub9G5QLBzvI6x7%2BWSCpxATDszR3bX0KRAp2cz2bVe0r5lolkZGQ9yyGP%2B2Q0MthsUgIApEbj57cWzmQy6msom23c7%2Bv6R8wUWHkVOEiR7wzvXK3Xp5JzM2yx57kDxM3bHW7XB2NjXiu8jV9mmFdnk6gGb%2BMQRS2LAioLiDtUt0vllhxBhBXDjkfCzwUC6hf%2FurKC0AL6nmW8WFSvnb1jxbDfjAxPkOSxkeHvBDR8FoW%2BeXud4w9fi7OInmIfCw8%2F1%2ByD2nD8t5GR7wVpJMN2okkXe75UmkrOIcmRs5lFZe9QlSROsxpfqyddAADaZjvyrS191vUS6JM8e25xUX2NlyB%2B9vg2eZ8uc345%2B1E2q77m237%2FiehIVZJ%2BlJz7Z76g0Ww1FAEAeLq%2F%2F0Qk7LVa5X9KjcbR%2BZsfttbm4z7f8UjYIe%2FTm88H37iROr%2FS4uK7QbpUq1%2FI5bSbqrZPwzOCcIlhng8G5W0PhmF7SbKtTv2iUrlfy1KUrXmNBcMO0VRGaOlx3CqV%2FtN8jKwdmp%2BPyIrVzjo13%2BpC6eUQa74myMBCqXSnXNZ0bmr0OCiyLIrThcLB1v5FpqOvNXO%2FlqXWY4ciPy%2BX1WcrNEWnEzNLgnAxl5sgSbl9JH%2FmXK02W2yJi4%2BZ%2FGSQll3wtdr7mYymh0PU6Hd0KCtWLzPMC8GgkiN7%2FO05ck8U5RypNRo%2FTCTR7h2%2FGl3PUOWq1c4cKXSsFzMs%2B7eVlX9pcyDkYeh98nbpQT2%2Bzj74%2F1a77zV1hwFnsZdF8VIuNxmkHWs9vn1koC1H9MeYQ%2BkP7IMzYjVpnAvDvq8xw7bUqaIkfb6q366hEyO%2FpqD0wSUAXr%2Be6roTjwRta41HIeRxewhCo0ODj043T8fQ8hXPQfTE%2BK87fkMwRUBMERBTBMQUATFFQEwREFMExBQBMUVATBEQUwTEFAExRUBMERBTBOT%2FAQAA%2F%2F98wKt7wQJ9rAAAAABJRU5ErkJggg%3D%3D&labelColor=202123">
+  </a>
+  <a href="https://github.com/raycast/script-commands/graphs/contributors">
+    <img alt="GitHub contributors" src="https://img.shields.io/github/stars/raycast?style=for-the-badge">
+  </a>
+  <a href="https://github.com/raycast/script-commands/stargazers">
+    <img alt="GitHub Org's stars" src="https://img.shields.io/github/contributors/raycast/script-commands?style=for-the-badge">
+  </a>
+  <a href="https://twitter.com/raycastapp">
+    <img alt="Twitter Follow" src="https://img.shields.io/twitter/follow/raycastapp?style=for-the-badge">
+  </a>
+</div>
+
+<div align="center">
   <a href="https://raycast.com">
     <img src="./images/logo.png" height="250px">
   </a>
@@ -7,23 +22,12 @@
   <br/>
   <h1>Raycast Script Commands</h1>
 
-  <!-- Images -->
-  <a href="https://github.com/raycast/script-commands/graphs/contributors">
-    <img alt="GitHub contributors" src="https://img.shields.io/github/contributors/raycast/script-commands">
-  </a>
-  <a href="https://twitter.com/raycastapp">
-    <img alt="Twitter Follow" src="https://img.shields.io/twitter/follow/raycastapp?style=social">
-  </a>
-  <a href="https://github.com/raycast/script-commands/stargazers">
-    <img alt="GitHub Org's stars" src="https://img.shields.io/github/stars/raycast?style=social">
-  </a>
-
-  <br/>
-  <br/>
   <i>Script Commands lets you tailor Raycast to your needs. <br/> Think of them as little productivity boosts throughout your day.</i>
-</div>
 
-<hr>
+  <hr>
+  <br/>
+  <br/>
+</div>
 
 [Raycast](https://raycast.com) lets you control your tools with a few keystrokes and Script Commands makes it possible to execute scripts from anywhere on your desktop. They are a great way to speed up every-day tasks such as converting data, opening bookmarks or triggering dev workflows.
 

--- a/Tools/Toolkit/Sources/ToolkitLibrary/Core/Documentation/Documentation.swift
+++ b/Tools/Toolkit/Sources/ToolkitLibrary/Core/Documentation/Documentation.swift
@@ -76,7 +76,7 @@ private extension Documentation {
 
     let markdown = """
       <!-- AUTO GENERATED FILE. DO NOT EDIT. -->
-      \(renderShieldBadge(total: raycastData.totalScriptCommands))
+      \(renderBadges())
 
       # Raycast Script Commands
 
@@ -117,7 +117,7 @@ private extension Documentation {
 
       contentString += .newLine
       contentString += .newLine + "| Icon | Title | Description | Author | Args | Templ | Lang |"
-      contentString += .newLine + "| ---- | ---- | ----------- | ------ | ---- | ----- | ----- |"
+      contentString += .newLine + "| ---- | ----- | ----------- | ------ | ---- | ----- | ---- |"
 
       for var scriptCommand in group.scriptCommands.sorted() {
         scriptCommand.configure(leadingPath: leadingPath)
@@ -133,15 +133,32 @@ private extension Documentation {
 
     return contentString
   }
-
-  func renderShieldBadge(total: Int) -> String {
+    
+  func renderBadges() -> String {
     let logo = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFgAAABYCAIAAAD+96djAAAIC0lEQVR4nOybW2zb1hmADynqLsuWRFLOBVmTpqkVy5LlpkgfDGRdnSvcdSiKIUWHosO8lwDtw4Bge1pRYMAw9KXAgAxYMiTNGjRZt+5plxQIkCzpNjduZMmJnMRpt7WR7NgSJYqULFISNUQ8pikpKVLpkOwDP+QhUajj40//f3j+n0fEY1sfByYA4EZP4JuCKQJiioCYIiCmCIgpAmKKgJgiIKYIiCkCYoqAmCIgpgiIKQJiioCYIiDGi9jidIQ8bqNnYbSIkNv9h7HY+7HRXf39xs7ESBFbnc5To5Gg3d5vtf4uMhLu8xg4GSNF7BroJ202+e9eK3EmNvr0gGFxYRnw+Y362SmeL1Rrzwb8AMMAAHYc30+Sl3JMtlrVfzJGigAAJDguXRH2kQHowmJ5Phi8kmeWRVHnmegt4gmXa7vLlRYE5ZUUz+ertT0BPwZd4JNBejpfWFJdowO6itjssJ8bix3euGGGZdOV9d8zwXFtOXKQoi4yuayoX47oJ2Kzw/HuaHSz00ng+H6K+pjJ31PFf4Lj+Hp93O9T4mKCJC8zTE6v9UI/Ec8M9B/euNGy9plPBulrrXERLxbvVip7SVJ24SGIFwaDuuWIfiI+K68u8KVDNIUpLmi6LUfm+VJnjuizduq6RnxWLmcqwgQZkF0QOH6Aoq51rBeda+elnObrhbYiQm73bt/AQqmsvJLi+YVSaS9Fyjlia8bFbLH4ZaWiXJPgOLWvtdgpZrTMEQ1FbHU634tFX9wwmCxy/11dBQAMEMSugX6x0ahJjRFvn3wZgeOHaGpREAI22xanU/7D1+sei2W7GxZjDovlgMY5gml0LCDkcZ+KRmi7HQAgStKRuRsXcrlxv+/3o9GuxyzWalPJuasFFulMIVrVGttcrsBaHWHD8Z9sewzreUwvQZwYCYfcmtTsWon4y/LKVGJOlCQAwE2OfyWeaKAY1mu1nh2LaVGnalh9XmSYI3M3Uhz3cny2UKuhGlauU2NeL6oBZVCK2Oyw7yNJ9SsXcrnJq58itCDjJYhT0cgQ0r4WMhHyDvrX4Z37qRYXSDJCZjpfkBpwPK+VOBmN7HC7UA2ORsQTLtefnoptc7lsOH4sPPzShkEkw7ZxbnHx6PxNxcWg3f7BU2OocgSNCJ/V6iUIOCKG/WroyYOtcYGKD5fuvXX7DlDiopkjSNZONCI+YdnXEklubS3AMeyd4Z0auTidTr95+446R87ERnvvgyNbI6YL7A/iCcWFDcdf3rQR1eBtnE6nfzp/S1LFRe998O5FbHU6v9+6FiQ57sfJuUq93suEHpE/Li39YmE9R3rvg3cpIuRxnx0b/eXQk69u2qR+fbpwP0d41PdLGWUZkjl59wE50nUfvJuia4vDcSY2GrTbMQx7NuBPV4QUzyv/m64I11h2kqYzgvDnpXstb3Q6Xxzs/obyzMBAosh90VqnouqDdxMRbovFga+9EcPeDj0gLqY0yBGHxXI8Et7d+pmfTqePzt9ScsSK457WwHlEuomIbLU6w7IHaMou68CwPQF/oVpLcJxyzZeVyr8LbLnVRY8R8bBejtIHFyTp9RupK/l8FyN32Y/ICMIVhpmkabsFb6q4nyN8vR4vFpVryh0R0bsIpZfT2QdnxOq76fQ/mG4s9NSYWRbFT1l2P0XaLRbQlDHu992tVOb50sPegkSEHBedffAkx6nbXF+XnvYRV1n2cHy2qNpHvR0aalsvEPL35RW5rgcA9BHEe7HobnTPSnvdUM3zpVfis8Xquou3dmzXyMVH2ewb11PK/bKvub9G5QLBzvI6x7+WSCpxATDszR3bX0KRAp2cz2bVe0r5lolkZGQ9yyGP+2Q0MthsUgIApEbj57cWzmQy6msom23c7+v6R8wUWHkVOEiR7wzvXK3Xp5JzM2yx57kDxM3bHW7XB2NjXiu8jV9mmFdnk6gGb+MQRS2LAioLiDtUt0vllhxBhBXDjkfCzwUC6hf/urKC0AL6nmW8WFSvnb1jxbDfjAxPkOSxkeHvBDR8FoW+eXud4w9fi7OInmIfCw8/1+yD2nD8t5GR7wVpJMN2okkXe75UmkrOIcmRs5lFZe9QlSROsxpfqyddAADaZjvyrS191vUS6JM8e25xUX2NlyB+9vg2eZ8uc345+1E2q77m237/iehIVZJ+lJz7Z76g0Ww1FAEAeLq//0Qk7LVa5X9KjcbR+Zsfttbm4z7f8UjYIe/Tm88H37iROr/S4uK7QbpUq1/I5bSbqrZPwzOCcIlhng8G5W0PhmF7SbKtTv2iUrlfy1KUrXmNBcMO0VRGaOlx3CqV/tN8jKwdmp+PyIrVzjo13+pC6eUQa74myMBCqXSnXNZ0bmr0OCiyLIrThcLB1v5FpqOvNXO/lqXWY4ciPy+X1WcrNEWnEzNLgnAxl5sgSbl9JH/mXK02W2yJi4+Z/GSQll3wtdr7mYymh0PU6Hd0KCtWLzPMC8GgkiN7/O05ck8U5RypNRo/TCTR7h2/Gl3PUOWq1c4cKXSsFzMs+7eVlX9pcyDkYeh98nbpQT2+zj74/1a77zV1hwFnsZdF8VIuNxmkHWs9vn1koC1H9MeYQ+kP7IMzYjVpnAvDvq8xw7bUqaIkfb6q366hEyO/pqD0wSUAXr+e6roTjwRta41HIeRxewhCo0ODj043T8fQ8hXPQfTE+K87fkMwRUBMERBTBMQUATFFQEwREFMExBQBMUVATBEQUwTEFAExRUBMERBTBOT/AQAA//98wKt7wQJ9rAAAAABJRU5ErkJggg=="
-
-    let style                = "for-the-badge"
-    let rightPartColor       = "red"
-    let labelBackgroundColor = "202123"
-    let badge = "[![Raycast Script Commands](https://img.shields.io/badge/Script%20Commands-\(total)-\(rightPartColor)?style=\(style)&logo=\(logo)&labelColor=\(labelBackgroundColor))](https://github.com/raycast/script-commands)"
-
-    return badge
+    
+    let style      = "for-the-badge"
+    let labelColor = "202123"
+    let dataURL    = "https:%2F%2Fraw.githubusercontent.com%2Fraycast%2Fscript-commands%2Fmaster%2Fcommands%2Fextensions.json"
+    let jsonPath   = "$.totalScriptCommands"
+    
+    let badges = """
+    <div align="center">
+      <a href="https://github.com/raycast/script-commands">
+        <img alt="GitHub contributors" src="https://img.shields.io/badge/dynamic/json?style=\(style)&color=\(labelColor)&label=Script%20Commands&query=\(jsonPath)&url=\(dataURL)&logo=\(logo)&labelColor=\(labelColor)">
+      </a>
+      <a href="https://github.com/raycast/script-commands/graphs/contributors">
+        <img alt="GitHub contributors" src="https://img.shields.io/github/stars/raycast?style=\(style)">
+      </a>
+      <a href="https://github.com/raycast/script-commands/stargazers">
+        <img alt="GitHub Org's stars" src="https://img.shields.io/github/contributors/raycast/script-commands?style=\(style)">
+      </a>
+      <a href="https://twitter.com/raycastapp">
+        <img alt="Twitter Follow" src="https://img.shields.io/twitter/follow/raycastapp?style=\(style)">
+      </a>
+    </div>
+    """
+    
+    return badges
   }
 }


### PR DESCRIPTION
## Description

A small addition of badges to our Awesome Script Commands ([commands/](https://github.com/raycast/script-commands/tree/master/commands) folder) and update the badge style in the main README.

## Type of change

- [x] Documentation update

## Screenshot

<!-- If it's a new script command, please include a screenshot or a GIF of how it works. -->
![image](https://user-images.githubusercontent.com/83694/109393080-1305e580-7920-11eb-8d43-50838c3e189a.png)

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)