### PR TITLE
Fix extension.json hyperlink

### DIFF
--- a/Tools/Toolkit/CONTRIBUTING.md
+++ b/Tools/Toolkit/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to Raycast's Toolkit
 
-Raycast Toolkit is a command-line application for automating repetitive tasks in this repo. At the moment the Toolkit automates the generation of the [Awesome Script Commands](../../commands/README.md) and the [extensions.json](../../extensions.json) which contains information about each Script Command.
+Raycast Toolkit is a command-line application for automating repetitive tasks in this repo. At the moment the Toolkit automates the generation of the [Awesome Script Commands](../../commands/README.md) and the [extensions.json](../../commands/extensions.json) which contains information about each Script Command.
 
 ## Tech Stack
 


### PR DESCRIPTION
## Description

<!-- Please write a short summary for this change. If it's a new script command, explain what it does. -->
Updated a hyperlink from Toolkit's `CONTRIBUTING.md` that was pointing towards an invalid path.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Documentation update

## Screenshot

<!-- If it's a new script command, please include a screenshot or a GIF of how it works. -->

## Dependencies / Requirements

<!-- If it's a new script command that requires some additional steps to make it work, please describe it here. E.g. requiring installation of another command line tool or requirement to specify username / API token / etc. -->

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)