### PR TITLE
Improve run-bash-command.sh

### DIFF
--- a/commands/developer-utils/run-bash-command.sh
+++ b/commands/developer-utils/run-bash-command.sh
@@ -5,13 +5,11 @@
 #                                                                             #
 # Description: run arbitrary bash command and show ouput in Raycast window.   #                                                                            #
 #                                                                             #
-# Usage:                                                                      #
-#             > <dir> <command>                                               #
 # Arguments:                                                                  #
-#             <dir> the directory where your command will be excuted.         #
-#                   * If blank, it uses current finder directory.             #
 #         <command> Your arbitrary bash commands (oneliner).                  #
 #                   * If blank, it opens the Terminal app and cd to <dir>.    #
+#       <directory> The directory where your command will be excuted.         #
+#                   * If blank, it uses current finder directory.             #
 #                                                                             #
 ###############################################################################
 #
@@ -47,7 +45,7 @@ fi
 if [ -z "$cmd" ] ; then
 	osascript -e "set dir to \"$dir\"" -e "dir" -e "tell application \"Terminal\"" -e "do script \"cd \" & quoted form of dir" -e "activate" -e "end tell"
 else
-	TERM="xterm-256color" ; export TERM
+	TERM="linux" ; export TERM
 	cd "$dir"
 	eval "$cmd"
 	cd "$OLDPWD"

--- a/commands/developer-utils/run-bash-command.sh
+++ b/commands/developer-utils/run-bash-command.sh
@@ -9,7 +9,8 @@
 #         <command> Your arbitrary bash commands (oneliner).                  #
 #                   * If blank, it opens the Terminal app and cd to <dir>.    #
 #       <directory> The directory where your command will be excuted.         #
-#                   * If blank, it uses current finder directory.             #
+#                   * If blank, it uses current Finder directory.             #
+#                     * If no open Finder window, then use $HOME.             #
 #                                                                             #
 ###############################################################################
 #
@@ -33,7 +34,7 @@ dir="${2/#\~/$HOME}"
 
 # Parse directory
 if [ -z "$dir" ] ; then
-	finder_dir=$( osascript -e "tell application \"Finder\"" -e "set pathList to (POSIX path of (folder of the front window as alias))" -e "pathList" -e "end tell" )
+	finder_dir=$( osascript -e "tell application \"Finder\"" -e "if exists window 1 then" -e "set pathList to (POSIX path of (folder of the front window as alias))" -e "pathList" -e "end if" -e "end tell" )
 	if [ -z "$finder_dir" ] ; then
 		dir="${HOME}"
 	else


### PR DESCRIPTION
## Description

Improve `developer-utils/run-bash-command.sh`:

1. Modify `$TERM` to `linux` to generate correct colored output, according to @grzegorzkrukowski 's [solution](https://github.com/raycast/script-commands/issues/22#issuecomment-789969644). 
2. Fix: if there's no open Finder window, the script with use `$HOME` as directory.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] New script command
- [ ] Bug fix
- [x] Improvement of an existing script
- [ ] Documentation update
- [ ] Toolkit change
- [ ] Other (Specify)

## Screenshot

<!-- If it's a new script command, please include a screenshot or a GIF of how it works. -->
```bash
echo "Hello!"; echo "$(tput setaf 8)Hello!$(tput sgr0)"; echo "$(tput setaf 1)Hello!$(tput sgr0)";
```

**Before:**
![before](https://user-images.githubusercontent.com/42609034/109864633-58e5e500-7c63-11eb-8d99-2bc1325084fd.png)

**After:**
![Screen Shot 2021-03-03 at 8 52 38 PM](https://user-images.githubusercontent.com/42609034/109863893-75cde880-7c62-11eb-9c73-876c53af5570.png)

## Dependencies / Requirements

<!-- If it's a new script command that requires some additional steps to make it work, please describe it here. E.g. requiring installation of another command line tool or requirement to specify username / API token / etc. -->
None.

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)