### PR TITLE
Suppress error 128 when emptying an already empty Trash

### DIFF
--- a/commands/system/empty-trash.applescript
+++ b/commands/system/empty-trash.applescript
@@ -12,4 +12,8 @@
 # Documentation:
 # @raycast.description Empty the trash.
 
-tell application "Finder" to empty trash
+on run
+    try
+		tell application "Finder" to empty trash
+	end try
+end run

--- a/commands/system/empty-trash.applescript
+++ b/commands/system/empty-trash.applescript
@@ -14,6 +14,6 @@
 
 on run
     try
-		tell application "Finder" to empty trash
-	end try
+        tell application "Finder" to empty trash
+    end try
 end run

--- a/commands/system/empty-trash.applescript
+++ b/commands/system/empty-trash.applescript
@@ -13,7 +13,7 @@
 # @raycast.description Empty the trash.
 
 on run
-    try
-        tell application "Finder" to empty trash
-    end try
+	try
+		tell application "Finder" to empty trash
+	end try
 end run

--- a/commands/system/restart-dock.sh
+++ b/commands/system/restart-dock.sh
@@ -16,4 +16,4 @@
 
 killall Dock
 
-echo "Restarted the Dock" 
+echo "Restarted the Dock"

--- a/commands/system/restart-dock.sh
+++ b/commands/system/restart-dock.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Restart the Dock
+# @raycast.mode compact
+# @raycast.packageName System
+
+# Optional parameters:
+# @raycast.icon 💀
+# @raycast.author Jordi Clement
+# @raycast.authorURL https://github.com/jordicl
+
+# Documentation:
+# @raycast.description Restart the Dock
+
+killall Dock
+
+echo "Restarted the Dock" 


### PR DESCRIPTION
## Description

This change to the applescript suppresses the (otherwise harmless) Applescript Error 128 that gets thrown when emptying an already empty Trash. 

## Type of change

- [ ] New script command
- [ ] Bug fix
- [X ] Improvement of an existing script
- [ ] Documentation update
- [ ] Toolkit change
- [ ] Other (Specify)

## Checklist

- [X] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)