### PR TITLE
fix error 128

### DIFF
--- a/commands/system/empty-trash.applescript
+++ b/commands/system/empty-trash.applescript
@@ -12,4 +12,8 @@
 # Documentation:
 # @raycast.description Empty the trash.
 
-tell application "Finder" to empty trash
+on run
+  try
+    tell application "Finder" to empty trash
+  end try
+end run


### PR DESCRIPTION
## Description

This change suppresses the error 128 when emptying an already empty Trash. 

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)