### PR TITLE
Update open-terminal-from-finder.applescript

### DIFF
--- a/commands/navigation/open-terminal-from-finder.applescript
+++ b/commands/navigation/open-terminal-from-finder.applescript
@@ -15,15 +15,41 @@
 # @raycast.authorURL https://github.com/japanese-goblinn
 
 tell application "Finder"
-    set pathList to (quoted form of POSIX path of (folder of the front window as alias))
-    set command to "clear; cd " & pathList
+    -- Check if there's a selection; works if there's a window open or not.
+    if selection is not {} then
+        set i to item 1 of (get selection)
+
+        -- If it's an alias, set the item to the original item.
+        if class of i is alias file then
+            set i to original item of i
+        end if
+
+        -- If it's a folder, use its path.
+        if class of i is folder then
+            set path to i
+        else
+            -- If it's an item, use its container's path.
+            set path to container of i
+        end if
+    else if (exists window 1) and current view of window 1 is in {list view, flow view} then
+        -- If a window exist, use its folder property as the path.
+        set path to folder of window 1
+    else
+        -- Fallback to the Desktop, as nothing is open or selected.
+        set path to path to desktop folder
+    end if
+
+    set command to "clear; cd " & quoted form of POSIX path of (path as alias)
 end tell
-  
+
 tell application "Terminal"
     if not (exists window 1) then reopen
-        activate
+
+    activate
+
     if busy of window 1 then
         tell application "System Events" to keystroke "t" using command down
     end if
+
     do script command in window 1
 end tell

--- a/commands/navigation/open-terminal-from-finder.applescript
+++ b/commands/navigation/open-terminal-from-finder.applescript
@@ -39,7 +39,7 @@ tell application "Finder"
         set p to path to desktop folder
     end if
 
-    set command to "clear; cd " & quoted form of POSIX path of (p as alias)
+    set command to "cd " & quoted form of POSIX path of (p as alias)
 end tell
 
 tell application "Terminal"

--- a/commands/navigation/open-terminal-from-finder.applescript
+++ b/commands/navigation/open-terminal-from-finder.applescript
@@ -26,20 +26,20 @@ tell application "Finder"
 
         -- If it's a folder, use its path.
         if class of i is folder then
-            set path to i
+            set p to i
         else
             -- If it's an item, use its container's path.
-            set path to container of i
+            set p to container of i
         end if
     else if (exists window 1) and current view of window 1 is in {list view, flow view} then
         -- If a window exist, use its folder property as the path.
-        set path to folder of window 1
+        set p to folder of window 1
     else
         -- Fallback to the Desktop, as nothing is open or selected.
-        set path to path to desktop folder
+        set p to path to desktop folder
     end if
 
-    set command to "clear; cd " & quoted form of POSIX path of (path as alias)
+    set command to "clear; cd " & quoted form of POSIX path of (p as alias)
 end tell
 
 tell application "Terminal"

--- a/commands/navigation/open-terminal-from-finder.applescript
+++ b/commands/navigation/open-terminal-from-finder.applescript
@@ -53,3 +53,5 @@ tell application "Terminal"
 
     do script command in window 1
 end tell
+
+return ""


### PR DESCRIPTION
## Description

Added logic to check for window, selection and type of selection (alias, file, folder).

I would argue against `clear;` in the final command, but the original implementation not being mine, I've left it as is. My argument against it is that you might have output that you need, the most basic example being comparing two `ls` outputs.

## Type of change

- [x] Bug fix
- [x] Improvement of an existing script

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)