### PR TITLE
Go to a an artists page in apple music

### DIFF
--- a/commands/media/apple-music/apple-music-go-to-artist-page.sh
+++ b/commands/media/apple-music/apple-music-go-to-artist-page.sh
@@ -9,7 +9,7 @@
 # Optional parameters:
 # @raycast.author Jordi Clement
 # @raycast.authorURL https://github.com/jordicl
-# @raycast.description images/apple-music-logo.png
+# @raycast.description Go to Artist page in the Apple Music App
 # @raycast.argument1 { "type": "text", "placeholder": "artist", "percentEncoded": true}
 # @raycast.icon images/apple-music-logo.png
 

--- a/commands/media/apple-music/apple-music-go-to-artist-page.sh
+++ b/commands/media/apple-music/apple-music-go-to-artist-page.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Dependency: This script requires `jq` cli installed: https://stedolan.github.io/jq/
+# Install via homebrew: `brew install jq`
+
 # Required parameters:
 # @raycast.schemaVersion 1
 # @raycast.title Go to Artist in Apple Music
@@ -14,7 +17,7 @@
 # @raycast.icon images/apple-music-logo.png
 
 if ! command -v jq &> /dev/null; then
-	echo "jq is required. Install using Brew";
+	echo "jq is required. Install using homebrew: brew install jq";
 	exit 1;
 fi
 

--- a/commands/media/apple-music/apple-music-go-to-artist-page.sh
+++ b/commands/media/apple-music/apple-music-go-to-artist-page.sh
@@ -13,5 +13,10 @@
 # @raycast.argument1 { "type": "text", "placeholder": "artist", "percentEncoded": true}
 # @raycast.icon images/apple-music-logo.png
 
+if ! command -v jq &> /dev/null; then
+	echo "jq is required. Install using Brew";
+	exit 1;
+fi
+
 url=$(curl -s https://itunes.apple.com/search\?term=$1\&entity=musicArtist | jq '.results[0].artistLinkUrl' | sed 's/https/itms/g' | sed 's/"//g')
 osascript -e 'on run {myurl}' -e 'open location myurl' -e 'end run' $url

--- a/commands/media/apple-music/apple-music-go-to-artist-page.sh
+++ b/commands/media/apple-music/apple-music-go-to-artist-page.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Go to Artist in Apple Music
+# @raycast.mode silent
+# @raycast.packageName Music
+
+# Optional parameters:
+# @raycast.author Jordi Clement
+# @raycast.authorURL https://github.com/jordicl
+# @raycast.description images/apple-music-logo.png
+# @raycast.argument1 { "type": "text", "placeholder": "artist", "percentEncoded": true}
+# @raycast.icon images/apple-music-logo.png
+
+url=$(curl -s https://itunes.apple.com/search\?term=$1\&entity=musicArtist | jq '.results[0].artistLinkUrl' | sed 's/https/itms/g' | sed 's/"//g')
+osascript -e 'on run {myurl}' -e 'open location myurl' -e 'end run' $url


### PR DESCRIPTION
## Description

This command provides a convenient way to open an artist's page in Apple Music. It works most of the time, but you'll get the best results using the exact artist's name: it currently just opens the first result of the query. When the RayCast API is available I'll implement something proper.

## Type of change

- [x] New script command

## Screenshot

<img width="862" alt="Screenshot 2021-03-05 at 16 57 06" src="https://user-images.githubusercontent.com/292306/110140125-0b3cba00-7dd4-11eb-914d-a1835063ae1d.png">
<img width="1475" alt="Screenshot 2021-03-05 at 16 57 35" src="https://user-images.githubusercontent.com/292306/110140141-0ed04100-7dd4-11eb-9155-230ca62d8c03.png">

## Dependencies / Requirements

There is a dependency on jq. Install using `brew install jq`

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)