### PR TITLE
New Script: network-status.sh

### DIFF
--- a/commands/system/network-status.sh
+++ b/commands/system/network-status.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Network Status
+# @raycast.mode inline
+# @raycast.refreshTime 1m
+
+# Optional parameters:
+# @raycast.icon 📶
+
+# @Documentation:
+# @raycast.packageName System
+# @raycast.description Get current network connections.
+# @raycast.author Alexandru Turcanu
+# @raycast.authorURL https://github.com/Pondorasti
+
+function get_wifi_ssid () {
+  service_info=$(/System/Library/PrivateFrameworks/Apple80211.framework/Versions/A/Resources/airport --getinfo)
+  ssid_line=$(echo "$service_info" | grep -v "BSSID" | grep "SSID")
+  ssid=$(echo "$ssid_line" | awk -F "(: )" '{print $2}')
+
+  echo "$ssid"
+}
+
+current_device=$(route get default 2>/dev/null | grep "interface" | awk '{print $2}')
+
+# Exit if there's no connection
+if [ -z "$current_device" ]; then
+  echo "No connection"
+  exit 0;
+fi
+
+service_info=$(networksetup -listnetworkserviceorder | grep "$current_device")
+service_name=$(echo "$service_info" | awk -F  "(, )|(: )|[)]" '{print $2}')
+wifi_ssid=$(get_wifi_ssid)
+network_status=""
+
+if grep -q "USB" <<< "$service_name"; then
+  network_status+="Ethernet"
+
+  # Check if also connected to Wi-fi
+  if [ -n "$wifi_ssid" ]; then
+    network_status+=" | $wifi_ssid"
+  fi
+elif grep -q "Wi-Fi" <<< "$service_name"; then
+  network_status+="$wifi_ssid"
+fi
+
+echo "$network_status"

--- a/commands/system/network-status.sh
+++ b/commands/system/network-status.sh
@@ -24,8 +24,7 @@ function get_wifi_ssid () {
 }
 
 function get_internet_status () {
-  ping_result=$(ping -c 2 google.com)
-  if grep -q "Request timeout" <<< "$ping_result" || grep -q "cannot resolve" <<< "$ping_result"; then
+  if ! ping -q -c 2 google.com &>/dev/null; then
     echo " (No Internet)"
   fi
 }

--- a/commands/system/network-status.sh
+++ b/commands/system/network-status.sh
@@ -23,6 +23,13 @@ function get_wifi_ssid () {
   echo "$ssid"
 }
 
+function get_internet_status () {
+  ping_result=$(ping -c 2 google.com)
+  if grep -q "Request timeout" <<< "$ping_result" || grep -q "cannot resolve" <<< "$ping_result"; then
+    echo " (No Internet)"
+  fi
+}
+
 current_device=$(route get default 2>/dev/null | grep "interface" | awk '{print $2}')
 
 # Exit if there's no connection
@@ -38,6 +45,7 @@ network_status=""
 
 if grep -q "USB" <<< "$service_name"; then
   network_status+="Ethernet"
+  network_status+=$(get_internet_status)
 
   # Check if also connected to Wi-fi
   if [ -n "$wifi_ssid" ]; then
@@ -45,6 +53,7 @@ if grep -q "USB" <<< "$service_name"; then
   fi
 elif grep -q "Wi-Fi" <<< "$service_name"; then
   network_status+="$wifi_ssid"
+  network_status+=$(get_internet_status)
 fi
 
 echo "$network_status"


### PR DESCRIPTION
## Description

<!-- Please write a short summary for this change. If it's a new script command, explain what it does. -->

System script that detects your current network connections. It can have the following states:
* `Ethernet`
* `Ethernet | <wifi-name>`
* `<wifi-name>`
* `No connection`

I'm open to any feedback 🙂. For the icon I have also considered these 2 emojis 🌐 📡, and the `wifi` segment was initially using this style `Wi-fi (<wifi-name>)`

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New script command

## Screenshot

<!-- If it's a new script command, please include a screenshot or a GIF of how it works. -->

https://user-images.githubusercontent.com/32957606/110263534-debba600-7f6b-11eb-9d99-c0f6c8e535cb.mov


## Dependencies / Requirements

<!-- If it's a new script command that requires some additional steps to make it work, please describe it here. E.g. requiring installation of another command line tool or requirement to specify username / API token / etc. -->

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)