### PR TITLE
bitwarden: fix clipboard copy error that may include newline and message when copying password for a non-existing account

### DIFF
--- a/commands/password-managers/bitwarden/copy-first-matching-password.sh
+++ b/commands/password-managers/bitwarden/copy-first-matching-password.sh
@@ -54,7 +54,7 @@ if [[ -z $name || -z $password || ( $name == "null" && $password == "null") ]]; 
   exit 1
 fi
 
-echo $password | tr -d " \t\n\r" | pbcopy
 unset $password
+echo -n $password | pbcopy
 echo "Copied the password for '$name' to the clipboard."
 exit 0

--- a/commands/password-managers/bitwarden/copy-first-matching-password.sh
+++ b/commands/password-managers/bitwarden/copy-first-matching-password.sh
@@ -50,8 +50,8 @@ if [ $unlocked_status -ne 0 ]; then
 fi
 
 item=$(bw list items --search $1 $session 2> /dev/null | jq ".[0] | { name: .name, password: .login.password }")
-name=$(echo $item | jq -e ".name") || notFoundError
-password=$(echo $item | jq -re ".password") || notFoundError
+name=$(echo $item | jq --exit-status ".name") || notFoundError
+password=$(echo $item | jq --raw-output --exit-status ".password") || notFoundError
 
 echo -n $password | pbcopy
 unset password

--- a/commands/password-managers/bitwarden/copy-first-matching-password.sh
+++ b/commands/password-managers/bitwarden/copy-first-matching-password.sh
@@ -54,7 +54,7 @@ if [[ -z $name || -z $password ]]; then
   exit 1
 fi
 
-echo $password | pbcopy
+echo $password | tr -d " \t\n\r" | pbcopy
 unset $password
 echo "Copied the password for '$name' to the clipboard."
 exit 0

--- a/commands/password-managers/bitwarden/copy-first-matching-password.sh
+++ b/commands/password-managers/bitwarden/copy-first-matching-password.sh
@@ -21,7 +21,7 @@
 # @raycast.authorURL https://github.com/PSalant726
 # @raycast.description Search all items in a Bitwarden vault, and copy the password of the first search result to the clipboard.
 notFound() {
-  echo -n "The query '$1' did not return a password."
+  echo "The query '$1' did not return a password."
   exit 1
 }
 

--- a/commands/password-managers/bitwarden/copy-first-matching-password.sh
+++ b/commands/password-managers/bitwarden/copy-first-matching-password.sh
@@ -20,6 +20,7 @@
 # @raycast.author Phil Salant
 # @raycast.authorURL https://github.com/PSalant726
 # @raycast.description Search all items in a Bitwarden vault, and copy the password of the first search result to the clipboard.
+
 notFound() {
   echo "The query '$1' did not return a password."
   exit 1
@@ -56,5 +57,4 @@ password=$(echo $item | jq --raw-output --exit-status ".password") || notFoundEr
 echo -n $password | pbcopy
 unset password
 echo "Copied the password for '$name' to the clipboard."
-unset name
 exit 0

--- a/commands/password-managers/bitwarden/copy-first-matching-password.sh
+++ b/commands/password-managers/bitwarden/copy-first-matching-password.sh
@@ -49,7 +49,7 @@ item=$(bw list items --search $1 $session 2> /dev/null | jq ".[0] | { name: .nam
 name=$(echo $item | jq ".name")
 password=$(echo $item | jq --raw-output ".password")
 
-if [[ -z $name || -z $password ]]; then
+if [[ -z $name || -z $password || ( $name == "null" && $password == "null") ]]; then
   echo "The query '$1' did not return a password."
   exit 1
 fi

--- a/commands/password-managers/bitwarden/copy-first-matching-password.sh
+++ b/commands/password-managers/bitwarden/copy-first-matching-password.sh
@@ -53,7 +53,8 @@ item=$(bw list items --search $1 $session 2> /dev/null | jq ".[0] | { name: .nam
 name=$(echo $item | jq -e ".name") || notFoundError
 password=$(echo $item | jq -re ".password") || notFoundError
 
-unset $password
 echo -n $password | pbcopy
+unset password
 echo "Copied the password for '$name' to the clipboard."
+unset name
 exit 0


### PR DESCRIPTION
## Description

This is fixing a bug that was adding a newline at the end of the copied password and a bug on displayed message when copying password for a non-existing account (example bellow)

## Type of change

- [ ] Bug fix

## Screenshot
The first call is performed before changes, the second one is before after my changes.
<img width="632" alt="Screenshot 2021-03-08 at 19 01 54" src="https://user-images.githubusercontent.com/19294297/110362469-9a9ad500-8041-11eb-8d98-898d0907055e.png">


## Checklist

- [ x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)