### PR TITLE
Quit app script

### DIFF
--- a/commands/system/quit-app.swift
+++ b/commands/system/quit-app.swift
@@ -1,0 +1,50 @@
+#!/usr/bin/swift
+
+// Required parameters:
+// @raycast.schemaVersion 1
+// @raycast.title Quit app
+// @raycast.mode silent
+// @raycast.packageName System
+
+// Optional parameters:
+// @raycast.icon 💥
+// @raycast.argument1 { "type": "text", "placeholder": "Name or pid" }
+
+// Documentation:
+// @raycast.description Quits an app, by name or process id.
+// @raycast.author Roland Leth
+// @raycast.authorURL https://runtimesharks.com
+
+import AppKit
+
+let argument = Array(CommandLine.arguments.dropFirst()).first!
+
+if let processId = Int(argument) {
+	guard
+		let app = NSWorkspace.shared
+			.runningApplications
+			.first(where: { $0.processIdentifier == processId })
+	else {
+		print("Couldn't find app with process id \(processId)")
+		exit(1)
+	}
+
+	app.terminate()
+
+	print("Quit \(app.localizedName ?? "\(processId)")")
+} else {
+	guard
+		let app = NSWorkspace.shared
+			.runningApplications
+			.first(where: {
+				$0.localizedName?.localizedCaseInsensitiveContains(argument) == true
+			})
+	else {
+		print("Couldn't find app with name \(argument)")
+		exit(1)
+	}
+
+	app.terminate()
+
+	print("Quit \(app.localizedName ?? argument)")
+}


### PR DESCRIPTION
## Description

Script that takes in a name or a process id and terminates it. I, personally, use it with "kill process" instead of "quit app", but not everyone is technical, so I went with a more friendly name for the public version. But I'm up for debate on this one, because I'm not totally sure how it should go for the public. I also tried "Terminate app", but that also didn't feel right.

## Type of change

- [x] New script command

## Screenshot

<img width="792" alt="Bildschirmfoto 2021-03-09 um 8 16 45 AM" src="https://user-images.githubusercontent.com/1858700/110427052-cce31b80-80af-11eb-9941-c54bce5e807b.png">

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)