### PR TITLE
List processes script

### DIFF
--- a/commands/system/list-processes.rb
+++ b/commands/system/list-processes.rb
@@ -1,0 +1,41 @@
+#!/usr/bin/ruby
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Running processes
+# @raycast.mode fullOutput
+# @raycast.packageName System
+
+# Optional parameters:
+# @raycast.icon 🔡
+# @raycast.argument3 { "type": "text", "placeholder": "Count (15)", "optional": true }
+
+# Documentation:
+# @raycast.description List running processes
+# @raycast.author Roland Leth
+# @raycast.authorURL https://runtimesharks.com
+
+# Adapted from https://github.com/ngreenstein/alfred-process-killer
+
+items = []
+count = ARGV[0] == "" || ARGV[0] == nil ? "15" : ARGV[0]
+
+# Assemble an array of each matching process. It will contain the process's path and percent CPU usage.
+# The -A flag shows all processes. The -o pid, -o %cpu, and -o comm show only the process's PID, CPU usage and path, respectively.
+# Grep for processes whose name contains the query. The regex isolates the name by only searching characters after the last slash in the path.
+#  The -i flag ignores case.
+
+processes = `ps -A -o pid -o %cpu -o comm | grep -i [^/]*[^/]*$ | sort -nrk 2,3 | head -n #{count}`.split("\n")
+
+processes.each do |process|
+	# Extract the PID, CPU usage, and path from the line (lines are in the form of `123 12.3 /path/to/process`).
+	processId, processCpu, processPath = process.match(/(\d+)\s+(\d+[\.|\,]\d+)\s+(.*)/).captures
+	# If an argument filter has been specified, get the arguments and search for the filter.
+
+	# Use the same expression as before to isolate the name of the process.
+	processName = processPath.match(/[^\/]*[^\/]*$/i)[0]
+
+	items.push(processCpu + "% @ " + processName + " (" + processId + ")")
+end
+
+puts items.join("\n")

--- a/commands/system/list-processes.rb
+++ b/commands/system/list-processes.rb
@@ -18,7 +18,7 @@
 
 items = []
 showPaths = ["yes", "y", "true"].include?(ARGV[0])
-count = ARGV[1] || "15"
+count = ARGV[1] == "" ? "15" : ARGV[1]
 
 # Assemble an array of each matching process.
 # -e shows all processes, -c shows only the executable name.

--- a/commands/system/list-processes.rb
+++ b/commands/system/list-processes.rb
@@ -8,17 +8,17 @@
 
 # Optional parameters:
 # @raycast.icon 🔡
-# @raycast.argument3 { "type": "text", "placeholder": "Count (15)", "optional": true }
+# @raycast.argument1 { "type": "text", "placeholder": "Paths (no)", "optional": true }
+# @raycast.argument2 { "type": "text", "placeholder": "Count (15)", "optional": true }
 
 # Documentation:
-# @raycast.description List running processes
+# @raycast.description List running app showing their process id, CPU usage, name, and optionally the process path.
 # @raycast.author Roland Leth
 # @raycast.authorURL https://runtimesharks.com
 
-# Adapted from https://github.com/ngreenstein/alfred-process-killer
-
 items = []
-count = ARGV[0] == "" || ARGV[0] == nil ? "15" : ARGV[0]
+showPaths = ["yes", "y", "true"].include?(ARGV[0])
+count = ARGV[1] || "15"
 
 # Assemble an array of each matching process.
 # -e shows all processes, -c shows only the executable name.
@@ -33,7 +33,13 @@ processes.each do |process|
 	# Isolate the name of the process.
 	processName = processPath.match(/[^\/]*[^\/]*$/i)[0]
 
-	items.push(processCpu + "% @ " + processName + " (" + processId + ")")
+	base = processCpu + "% @ " + processName + " (" + processId + ")"
+
+	if showPaths then
+		items.push(base + " -- " + processPath)
+	else
+		items.push(base)
+	end
 end
 
 puts items.join("\n")

--- a/commands/system/list-processes.rb
+++ b/commands/system/list-processes.rb
@@ -20,19 +20,17 @@
 items = []
 count = ARGV[0] == "" || ARGV[0] == nil ? "15" : ARGV[0]
 
-# Assemble an array of each matching process. It will contain the process's path and percent CPU usage.
-# The -A flag shows all processes. The -o pid, -o %cpu, and -o comm show only the process's PID, CPU usage and path, respectively.
-# Grep for processes whose name contains the query. The regex isolates the name by only searching characters after the last slash in the path.
-#  The -i flag ignores case.
+# Assemble an array of each matching process.
+# -e shows all processes, -c shows only the executable name.
+# The pid, pcpu, and comm show only the process's PID, CPU usage and path, respectively.
 
-processes = `ps -A -o pid -o %cpu -o comm | grep -i [^/]*[^/]*$ | sort -nrk 2,3 | head -n #{count}`.split("\n")
+processes = `ps -eo pid,pcpu,comm | sort -nrk 2,3 | head -n #{count}`.split("\n")
 
 processes.each do |process|
 	# Extract the PID, CPU usage, and path from the line (lines are in the form of `123 12.3 /path/to/process`).
 	processId, processCpu, processPath = process.match(/(\d+)\s+(\d+[\.|\,]\d+)\s+(.*)/).captures
-	# If an argument filter has been specified, get the arguments and search for the filter.
 
-	# Use the same expression as before to isolate the name of the process.
+	# Isolate the name of the process.
 	processName = processPath.match(/[^\/]*[^\/]*$/i)[0]
 
 	items.push(processCpu + "% @ " + processName + " (" + processId + ")")


### PR DESCRIPTION
## Description

Lists a given number of processes, showing name, process id and CPU usage (ordered by it). The parameter is optional, falling back to 15, which I felt is a reasonable amount to be easily readable, but also to provide enough information.

One of the big downsides of this is that when it runs, it slightly spikes in CPU usage, making Raycast and ruby always appear in the list as high usage. Not really sure that we should ignore them, either 🤔

## Type of change

- [x] New script command

## Screenshot

<img width="797" alt="2021-03-09 at 08 19 26" src="https://user-images.githubusercontent.com/1858700/110427448-6f9b9a00-80b0-11eb-8b8c-8b3f975b079f.png">

<img width="793" alt="2021-03-09 at 08 20 16" src="https://user-images.githubusercontent.com/1858700/110427434-68748c00-80b0-11eb-9379-12572478b639.png">

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)