### PR TITLE
Update open-folder-in-vscode.applescript

### DIFF
--- a/commands/developer-utils/open-folder-in-vscode.applescript
+++ b/commands/developer-utils/open-folder-in-vscode.applescript
@@ -15,7 +15,29 @@
 # @raycast.authorURL https://github.com/chohner
 
 tell application "Finder"
-    set pathList to (quoted form of POSIX path of (folder of the front window as alias))
+	# Check if there's a selection; works if there's a window open or not.
+	if selection is not {} then
+		set i to item 1 of (get selection)
+		
+		# If it's an alias, set the item to the original item.
+		if class of i is alias file then
+			set i to original item of i
+		end if
+		
+		# If it's a folder, use its path.
+		if class of i is folder then
+			set p to i
+		else
+			# If it's an item, use its container's path.
+			set p to container of i
+		end if
+	else if (exists window 1) and current view of window 1 is in {list view, flow view} then
+		# If a window exist, use its folder property as the path.
+		set p to folder of window 1
+	else
+		# Fallback to the Desktop, as nothing is open or selected.
+		set p to path to desktop folder
+	end if
 end tell
 
-do shell script "/usr/local/bin/code " & pathList
+do shell script "open -n -b \"com.microsoft.VSCode\" --args " & quoted form of POSIX path of (p as alias)


### PR DESCRIPTION
## Description

Added the same safety changes as the open-in-terminal script, for the cases where no window is open (you might have projects on your desktop).

I also changed the command because not everyone has `/usr/local/bin/code` (didn't even know it existed).

## Type of change

- [x] Improvement of an existing script

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)