### PR TITLE
Script to generate gitignore file

### DIFF
--- a/commands/developer-utils/generate-git-ignore.sh
+++ b/commands/developer-utils/generate-git-ignore.sh
@@ -3,7 +3,7 @@
 # Required parameters:
 # @raycast.schemaVersion 1
 # @raycast.title Generate a .gitignore file
-# @raycast.mode fullOutput
+# @raycast.mode silent
 # @raycast.packageName Developer Utilities
 
 # Optional parameters:

--- a/commands/developer-utils/generate-git-ignore.sh
+++ b/commands/developer-utils/generate-git-ignore.sh
@@ -4,7 +4,7 @@
 
 # Required parameters:
 # @raycast.schemaVersion 1
-# @raycast.title Generate a .gitignore file
+# @raycast.title Create .gitignore
 # @raycast.mode silent
 # @raycast.packageName Developer Utilities
 

--- a/commands/developer-utils/generate-git-ignore.sh
+++ b/commands/developer-utils/generate-git-ignore.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Generate a .gitignore file
+# @raycast.mode fullOutput
+# @raycast.packageName Developer Utilities
+
+# Optional parameters:
+# @raycast.icon 🤐
+# @raycast.argument1 { "type": "text", "placeholder": "Technologies (react,node,vscode)", "optional": true }
+
+# Documentation:
+# @raycast.description Generates a .gitignore file via https://gitignore.io
+# @raycast.author Roland Leth
+# @raycast.authorURL https://runtimesharks.com
+
+params="$1"
+
+if [[ -z "$params" ]]
+then
+	params="react,node,vscode"
+fi
+
+result=$(curl -s "https://www.toptal.com/developers/gitignore/api/$params")
+
+echo "$result" | pbcopy
+echo "$result"

--- a/commands/developer-utils/generate-git-ignore.sh
+++ b/commands/developer-utils/generate-git-ignore.sh
@@ -22,7 +22,7 @@ then
 	params="react,node,vscode"
 fi
 
-result=$(curl -s "https://www.toptal.com/developers/gitignore/api/$params")
+result=$(curl -s "https://www.toptal.com/developers/gitignore/api/$params" | sed -e "1d")
 
 echo "$result" | pbcopy
 echo "$result"

--- a/commands/developer-utils/generate-git-ignore.sh
+++ b/commands/developer-utils/generate-git-ignore.sh
@@ -24,5 +24,12 @@ fi
 
 result=$(curl -s "https://www.toptal.com/developers/gitignore/api/$params" | sed -e "1d")
 
+if [[ "$result" =~ !!\ ERROR.+!! ]]
+then
+	echo "The requested params couldn't be found"
+	exit 1
+fi
+
 echo "$result" | pbcopy
-echo "$result"
+
+echo "Copied to clipboard!"

--- a/commands/developer-utils/generate-git-ignore.sh
+++ b/commands/developer-utils/generate-git-ignore.sh
@@ -10,7 +10,7 @@
 
 # Optional parameters:
 # @raycast.icon 🤐
-# @raycast.argument1 { "type": "text", "placeholder": "Technologies (react,node,vscode)", "optional": true }
+# @raycast.argument1 { "type": "text", "placeholder": "Type (react,node,vscode)", "optional": false }
 
 # Documentation:
 # @raycast.description Generates a .gitignore file via https://gitignore.io

--- a/commands/developer-utils/generate-git-ignore.sh
+++ b/commands/developer-utils/generate-git-ignore.sh
@@ -10,7 +10,7 @@
 
 # Optional parameters:
 # @raycast.icon 🤐
-# @raycast.argument1 { "type": "text", "placeholder": "Type (react,node,vscode)", "optional": false }
+# @raycast.argument1 { "type": "text", "placeholder": "Types (react,node,vscode)", "optional": false }
 
 # Documentation:
 # @raycast.description Generates a .gitignore file via https://gitignore.io

--- a/commands/developer-utils/generate-git-ignore.sh
+++ b/commands/developer-utils/generate-git-ignore.sh
@@ -28,7 +28,7 @@ result=$(curl -s "https://www.toptal.com/developers/gitignore/api/$params" | sed
 
 if [[ "$result" =~ !!\ ERROR.+!! ]]
 then
-	echo "The requested params couldn't be found"
+	echo "Unsupported gitignore type"
 	exit 1
 fi
 

--- a/commands/developer-utils/generate-git-ignore.sh
+++ b/commands/developer-utils/generate-git-ignore.sh
@@ -21,7 +21,8 @@ params="$1"
 
 if [[ -z "$params" ]]
 then
-	params="react,node,vscode"
+	echo "Missing params"
+	exit 1
 fi
 
 result=$(curl -s "https://www.toptal.com/developers/gitignore/api/$params" | sed -e "1d")

--- a/commands/developer-utils/generate-git-ignore.sh
+++ b/commands/developer-utils/generate-git-ignore.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# List of available gitignore types: https://www.toptal.com/developers/gitignore/api/list
+
 # Required parameters:
 # @raycast.schemaVersion 1
 # @raycast.title Generate a .gitignore file


### PR DESCRIPTION
## Description

Calls https://gitignore.io to generate a `.gitignore` file for the given technologies and copies the result to clipboard.

## Type of change

- [x] New script command

## Screenshot

<img width="791" alt="2021-03-11 at 02 36 04" src="https://user-images.githubusercontent.com/1858700/110788309-20ec2c80-8277-11eb-990c-df76c5ae9b55.png">
<img width="784" alt="Bildschirmfoto 2021-03-11 um 2 37 10 PM" src="https://user-images.githubusercontent.com/1858700/110788434-45e09f80-8277-11eb-89aa-f66b28c354f6.png">

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)