### PR TITLE
Add script to uninstall apps with AppCleaner

### DIFF
--- a/commands/system/uninstall-with-appcleaner.applescript
+++ b/commands/system/uninstall-with-appcleaner.applescript
@@ -1,0 +1,25 @@
+#!/usr/bin/osascript
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Uninstall with AppCleaner
+# @raycast.mode silent
+# @raycast.packageName System
+# @raycast.argument1 { "type": "text", "placeholder": "Application", "optional": false }
+#
+# Optional parameters:
+# @raycast.icon 🗑
+#
+# Documentation:
+# @raycast.description Uninstall applications with AppCleaner
+# @raycast.author Felipe Turcheti
+# @raycast.authorURL https://felipeturcheti.com
+
+on run {appName}
+  set bundleId to id of application appName
+  tell application "Finder"
+    set appPath to (POSIX path of (application file id bundleId as alias))
+    do shell script "open -a AppCleaner \"" & appPath & "\""
+    log "Opening \"" & appName & "\" in AppCleaner…"
+  end tell
+end run


### PR DESCRIPTION
## Description

<!-- Please write a short summary for this change. If it's a new script command, explain what it does. -->
Add script to uninstall apps with [AppCleaner](https://freemacsoft.net/appcleaner/).

## Type of change

<!-- Please delete options that are not relevant. -->
- [x] New script command

## Screenshot

<!-- If it's a new script command, please include a screenshot or a GIF of how it works. -->
![01](https://user-images.githubusercontent.com/365403/111672771-1098fc00-87f9-11eb-8c50-8e43c2312f45.png)
![02](https://user-images.githubusercontent.com/365403/111672790-142c8300-87f9-11eb-9bd7-17e0aeb6a529.png)


## Dependencies / Requirements

<!-- If it's a new script command that requires some additional steps to make it work, please describe it here. E.g. requiring installation of another command line tool or requirement to specify username / API token / etc. -->
Requires the installation of AppCleaner: `brew install --cask appcleaner` or <https://freemacsoft.net/appcleaner/>

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)