### PR TITLE
Suggestion: url encode the title

### DIFF
--- a/commands/developer-utils/create-image-from-code.sh
+++ b/commands/developer-utils/create-image-from-code.sh
@@ -30,7 +30,7 @@ if [[ -z "$1" ]]
 then 
   TITLE="Untitled-1"
 else
-  TITLE=$1
+  TITLE=$(php -r "echo urlencode(\"$1\");")
 fi
 
 CODE=$(pbpaste | base64)


### PR DESCRIPTION
@thomaspaulmann : if the title contains spaces (maybe other characters), the command fails.

Using php as it should be available on every macOS, and I couldn't find an easy bash way to do it.

## Description

<!-- Please write a short summary for this change. If it's a new script command, explain what it does. -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] New script command
- [ ] Bug fix
- [x] Improvement of an existing script
- [ ] Documentation update
- [ ] Toolkit change
- [ ] Other (Specify)

## Screenshot

<!-- If it's a new script command, please include a screenshot or a GIF of how it works. -->

## Dependencies / Requirements

This uses php CLI, which should be available on every macOS.

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)