### PR TITLE
Rich text to markdown

### DIFF
--- a/commands/communication/rich-text-clipboard-to-markdown.sh
+++ b/commands/communication/rich-text-clipboard-to-markdown.sh
@@ -11,7 +11,7 @@
 # @raycast.icon 📝
 #
 # @raycast.mode silent
-# @raycast.packageName System
+# @raycast.packageName Communication
 # @raycast.schemaVersion 1
 
 if ! command -v pandoc &> /dev/null; then

--- a/commands/system/rich-text-clipboard-to-markdown.sh
+++ b/commands/system/rich-text-clipboard-to-markdown.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# @raycast.title rt2md
+# @raycast.author Adam Zethraeus
+# @raycast.authorURL https://github.com/adam-zethraeus
+# @raycast.description Convert rich text clipboard data to markdown using pandoc
+#
+# @raycast.icon 📝
+#
+# @raycast.mode silent
+# @raycast.packageName System
+# @raycast.schemaVersion 1
+
+export LC_CTYPE=UTF-8
+osascript -e 'the clipboard as "HTML"'| perl -ne 'print chr foreach unpack("C*",pack("H*",substr($_,11,-3)))' | pandoc --from=html --to=markdown | pbcopy

--- a/commands/system/rich-text-clipboard-to-markdown.sh
+++ b/commands/system/rich-text-clipboard-to-markdown.sh
@@ -1,15 +1,23 @@
 #!/bin/bash
 
-# @raycast.title rtf2md
+# @raycast.title Rich Text to Markdown
 # @raycast.author Adam Zethraeus
 # @raycast.authorURL https://github.com/adam-zethraeus
-# @raycast.description Convert rich text clipboard data to github flavoured markdown using pandoc
+# @raycast.description Convert rich text clipboard data to GitHub Flavoured Markdown using Pandoc
 #
 # @raycast.icon 📝
 #
 # @raycast.mode silent
 # @raycast.packageName System
 # @raycast.schemaVersion 1
+
+# Dependency: This script requires the `pandoc` cli to be installed: https://pandoc.org/
+# Install via homebrew: `brew install pandoc`
+
+if ! command -v pandoc &> /dev/null; then
+      echo "pandoc is required (https://pandoc.org/).";
+      exit 1;
+fi
 
 export LC_CTYPE=UTF-8
 osascript -e 'the clipboard as "HTML"'| perl -ne 'print chr foreach unpack("C*",pack("H*",substr($_,11,-3)))' | pandoc --from=html --to=gfm | pbcopy

--- a/commands/system/rich-text-clipboard-to-markdown.sh
+++ b/commands/system/rich-text-clipboard-to-markdown.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Dependency: This script requires the `pandoc` cli to be installed: https://pandoc.org/
+# Install via homebrew: `brew install pandoc`
+
 # @raycast.title Rich Text to Markdown
 # @raycast.author Adam Zethraeus
 # @raycast.authorURL https://github.com/adam-zethraeus
@@ -10,9 +13,6 @@
 # @raycast.mode silent
 # @raycast.packageName System
 # @raycast.schemaVersion 1
-
-# Dependency: This script requires the `pandoc` cli to be installed: https://pandoc.org/
-# Install via homebrew: `brew install pandoc`
 
 if ! command -v pandoc &> /dev/null; then
       echo "pandoc is required (https://pandoc.org/).";

--- a/commands/system/rich-text-clipboard-to-markdown.sh
+++ b/commands/system/rich-text-clipboard-to-markdown.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-# @raycast.title rt2md
+# @raycast.title rtf2md
 # @raycast.author Adam Zethraeus
 # @raycast.authorURL https://github.com/adam-zethraeus
-# @raycast.description Convert rich text clipboard data to markdown using pandoc
+# @raycast.description Convert rich text clipboard data to github flavoured markdown using pandoc
 #
 # @raycast.icon 📝
 #
@@ -12,4 +12,4 @@
 # @raycast.schemaVersion 1
 
 export LC_CTYPE=UTF-8
-osascript -e 'the clipboard as "HTML"'| perl -ne 'print chr foreach unpack("C*",pack("H*",substr($_,11,-3)))' | pandoc --from=html --to=markdown | pbcopy
+osascript -e 'the clipboard as "HTML"'| perl -ne 'print chr foreach unpack("C*",pack("H*",substr($_,11,-3)))' | pandoc --from=html --to=gfm | pbcopy


### PR DESCRIPTION
1. pastes clipboard as html through applescript call
2. processes output with perl to plain text
3. uses pandoc to convert html to github flavoured markdown
4. puts result back on clipboard

## Type of change

- [x] New script command

## Screenshot

![rtf2md](https://user-images.githubusercontent.com/509838/112059097-a940bc00-8b18-11eb-8d6d-9e94bb248689.gif)
 ^ now outputs github flavoured markdown instead.

## Dependencies / Requirements

Requires [pandoc](https://pandoc.org/).

`brew install pandoc`

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)