### PR TITLE
Support conversion of epoch in milliseconds for epoch-to-human-date.sh

### DIFF
--- a/commands/conversions/epoch-to-human-date.sh
+++ b/commands/conversions/epoch-to-human-date.sh
@@ -17,7 +17,14 @@
 # @raycast.authorURL https://github.com/kastnerorz
 
 epoch=${1}
-human=$(echo `date -r $epoch "+%F %T"`)
-echo -n "$human" | pbcopy
+size=${#epoch}
+if [[ $size == "10" ]];
+then
+        human=$(echo `date -r $epoch "+%F %T"`)
+        echo -n "$human" | pbcopy
+else
+        human=$(echo `date -r $(($epoch/1000)) "+%F %T"`)
+        echo -n "$human" | pbcopy
+fi
 
-echo "Converted $epoch to $human" 
+echo "Converted $epoch to $human"


### PR DESCRIPTION
## Description
Current command of `epoch-to-human-date.sh` only supports Unix time in seconds. This pull request enables conversion from Unix time in milliseconds.

## Type of change
- [x] Improvement of an existing script

## Screenshot
Not a new script.

## Dependencies / Requirements
Not needed.

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)