### PR TITLE
Add new conversion script "Unix Time Reader"

### DIFF
--- a/commands/conversions/unix-time-reader.sh
+++ b/commands/conversions/unix-time-reader.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# @raycast.schemaVersion 1
+# @raycast.title Unix Time Reader
+# @raycast.mode compact
+# @raycast.packageName Conversions
+#
+# @raycast.icon 🕰
+# @raycast.needsConfirmation false
+#
+# Documentation:
+# @raycast.description Display Human-Readable Date from Unix Time in Pasteboard
+# @raycast.author Francis Feng
+# @raycast.authorURL https://github.com/francisfeng
+
+unixTime=$(pbpaste)
+size=${#unixTime}
+
+if [[ $size == "10" ]]
+then
+        readable=$(echo `date -r $unixTime "+%F %T"`)
+elif [[ $size == "13" ]]
+then
+        readable=$(echo `date -r $(($unixTime/1000)) "+%F %T"`)
+else
+	echo "Not Unix Time in Pasteboard"
+	exit 1
+fi
+
+echo "$unixTime -> $readable"

--- a/commands/conversions/unix-time-reader.sh
+++ b/commands/conversions/unix-time-reader.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # @raycast.schemaVersion 1
-# @raycast.title Unix Time Reader
+# @raycast.title Unix Time Reader From Clipboard
 # @raycast.mode compact
 # @raycast.packageName Conversions
 #
@@ -9,7 +9,7 @@
 # @raycast.needsConfirmation false
 #
 # Documentation:
-# @raycast.description Display Human-Readable Date from Unix Time in Pasteboard
+# @raycast.description Display Human-Readable Date from Unix Time in Clipboard
 # @raycast.author Francis Feng
 # @raycast.authorURL https://github.com/francisfeng
 
@@ -23,7 +23,7 @@ elif [[ $size == "13" ]]
 then
         readable=$(echo `date -r $(($unixTime/1000)) "+%F %T"`)
 else
-	echo "Not Unix Time in Pasteboard"
+	echo "Unix Time is not found"
 	exit 1
 fi
 


### PR DESCRIPTION
## Description

Display Human-Readable Date from Unix Time in Pasteboard.

There is aleady a `epoch-to-human-date.sh` in this repository and I opened a pull request #339  about it just earlier today.

But Unix Time Reader is so different that I decided to make it as a new script. Specifically, it does not require any arguments, displays result in `compact` mode instead of the fleeting `silent` mode and does not copy the result to the clipboard. It also handles error.

## Type of change

- [x] New script command

## Screenshot

![image](https://user-images.githubusercontent.com/1040288/113006182-bbb99600-91a7-11eb-8cd3-a7de73ee60f5.png)

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)