### PR TITLE
Fix missing space in the if statement brackets

### DIFF
--- a/commands/apps/deepl/deepl-web-translate.sh
+++ b/commands/apps/deepl/deepl-web-translate.sh
@@ -58,7 +58,7 @@ if [ -z $2 ]; then
    toLang=$defaultLang
 fi
 
-if [ -z $3]; then
+if [ -z $3 ]; then
    fromLang=$defaultLang
 fi
 


### PR DESCRIPTION
## Description

Fix missing space in the if statement brackets

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix

## Screenshot

<!-- If it's a new script command, please include a screenshot or a GIF of how it works. -->

## Dependencies / Requirements

<!-- If it's a new script command that requires some additional steps to make it work, please describe it here. E.g. requiring installation of another command line tool or requirement to specify username / API token / etc. -->

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)