### PR TITLE
🌐 Add command to check domain name availability

### DIFF
--- a/commands/developer-utils/check-domain.template.sh
+++ b/commands/developer-utils/check-domain.template.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+# How to use this script
+# It's a template which needs some setup.
+# 1. Duplicate the file,
+# 2. remove `.template.` from the filename, and
+# 3. replace <token> with your API token.
+# Optionally, customize the script title, icon, and output.
+#
+# API docs:
+# https://vercel.com/docs/api#endpoints/domains/check-a-domain-availability
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Check Domain
+# @raycast.mode compact
+
+# Optional parameters:
+# @raycast.icon 🌐
+# @raycast.argument1 { "type": "text", "placeholder": "example.com" }
+# @raycast.packageName Developer Utils
+
+# @Documentation:
+# @raycast.description Check the availability of a domain with the Vercel API.
+# @raycast.author Ted Spare
+# @raycast.authorURL https://y.at/🤘🐊🗿🚀
+
+
+# Setup
+
+# Indicate that the script has started
+echo "Checking domain "$1"..."
+
+# Vercel API base URL
+API_URL="https://api.vercel.com/v4/domains/"
+
+# Authorization header required for making requests
+# <token> should be replaced with your token: https://vercel.com/account/tokens
+AUTH_HEADER="Authorization: Bearer <token>"
+
+
+# Main program
+
+# Query the Vercel API for the availability of the domain
+available=$(curl -s $API_URL"status?name="$1 -H "${AUTH_HEADER}")
+
+# If the domain is available, check its price. If unavailable, tell the user.
+# If there is an auth or other error, alert the user and throw an error.
+case $available in
+	*"true"*)
+		price=$(curl -s $API_URL"price?name="$1 -H "${AUTH_HEADER}")
+		# Extract the price from the JSON-formatted result
+		price=${price%,*}
+		price=${price##*:}
+		echo $1" is available for $"$price"! 🤑"
+		exit 0
+		;;
+	*"false"*)
+		echo $1" is not available 😢"
+		exit 0
+		;;
+	*"auth"*)
+		echo "Please provide a valid API token"
+		exit 1
+		;;
+	*)
+		echo "Something went wrong"
+		exit 1
+		;;
+esac

--- a/commands/developer-utils/check-domain.template.sh
+++ b/commands/developer-utils/check-domain.template.sh
@@ -49,6 +49,12 @@ available=$(curl -s $API_URL"status?name="$1 -H "${AUTH_HEADER}")
 case $available in
 	*"true"*)
 		price=$(curl -s $API_URL"price?name="$1 -H "${AUTH_HEADER}")
+		# Alert the user if the TLD is invalid
+		if [[ $price = *"tld"* ]]; then
+			tld=$(echo $1 | cut -d '.' -f2)
+			echo "Invalid TLD ."$tld
+			exit 1
+		fi
 		# Extract the price from the JSON-formatted result
 		price=${price%,*}
 		price=${price##*:}


### PR DESCRIPTION
## Description

This command uses the [Vercel](https://vercel.com/) API [domains endpoint](https://vercel.com/docs/api#endpoints/domains) to check a domain name's availability. The command takes a single argument, a domain name string, with placeholder `example.com`. If the domain is for sale, the command outputs its price to the user. If not, the user is told. If an auth or other error occurs, the user is alerted and the command throws an error with `exit 1`.

I've placed the script file in the root of `commands/developer-utils` because the functionality is fairly general. In the future, a dedicated `vercel` folder could cover Vercel-specific functionality.

👋  This is my first time contributing to a real open-source project so thank you for bearing with me! I'm likely missing some important steps so any feedback is welcome.

## Type of change

- [x] New script command

## Screenshot

Demo with unavailable and available domains:
![checkDomain](https://user-images.githubusercontent.com/36117635/114229025-48e9b100-9945-11eb-8d74-0ba28c8cd94b.gif)

## Dependencies / Requirements

**Requires a Vercel API token**, which can be found [here](https://vercel.com/account/tokens) after signing up for free [here](https://vercel.com/signup) (I have no affiliation with Vercel haha). The script file includes `.template.` and setup instructions are included in comments.

If requiring auth is enough of a barrier to users, I could look for an open domain search API! Let me know.

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)