### PR TITLE
Add command to say things

### DIFF
--- a/commands/communication/say.sh
+++ b/commands/communication/say.sh
@@ -3,7 +3,7 @@
 # @raycast.title Say
 # @raycast.author Felipe Turcheti
 # @raycast.authorURL https://github.com/fturcheti
-# @raycast.description Convert text to audible speech
+# @raycast.description Convert text to audible speech.
 
 # @raycast.icon 🗣
 # @raycast.mode silent

--- a/commands/communication/say.sh
+++ b/commands/communication/say.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# @raycast.title Say
+# @raycast.author Felipe Turcheti
+# @raycast.authorURL https://github.com/fturcheti
+# @raycast.description Convert text to audible speech
+
+# @raycast.icon 🗣
+# @raycast.mode silent
+# @raycast.packageName Communication
+# @raycast.schemaVersion 1
+
+# @raycast.argument1 { "type": "text", "placeholder": "Say this...", "optional": false }
+
+say "$1"

--- a/commands/communication/say.sh
+++ b/commands/communication/say.sh
@@ -2,7 +2,7 @@
 
 # @raycast.title Say
 # @raycast.author Felipe Turcheti
-# @raycast.authorURL https://github.com/fturcheti
+# @raycast.authorURL https://felipeturcheti.com
 # @raycast.description Convert text to audible speech.
 
 # @raycast.icon 🗣


### PR DESCRIPTION
## Description

<!-- Please write a short summary for this change. If it's a new script command, explain what it does. -->
Add command `communication/say.sh` that converts text to audible speech. It is just a wrapper for the CLI command `say` that's built-in macOS.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New script command

## Screenshot

<!-- If it's a new script command, please include a screenshot or a GIF of how it works. -->
<img width="900" alt="raycast-command-say" src="https://user-images.githubusercontent.com/365403/114729680-9768c800-9d16-11eb-83d3-49dd6efd3518.png">

## Dependencies / Requirements

<!-- If it's a new script command that requires some additional steps to make it work, please describe it here. E.g. requiring installation of another command line tool or requirement to specify username / API token / etc. -->

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)