### PR TITLE
Command to open Finder selection with a given app

### DIFF
--- a/commands/system/open-selection-with.applescript
+++ b/commands/system/open-selection-with.applescript
@@ -1,0 +1,42 @@
+#!/usr/bin/osascript
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Open Selection With
+# @raycast.mode silent
+# @raycast.packageName System
+# @raycast.argument1 { "type": "text", "placeholder": "Application", "optional": false }
+#
+# Optional parameters:
+# @raycast.icon 🗃
+#
+# Documentation:
+# @raycast.description Open selected items in Finder with the given application.
+# @raycast.author Felipe Turcheti
+# @raycast.authorURL https://felipeturcheti.com
+
+on run {appName}
+	log "Opening selection with \"" & appName & "\"…"
+
+	-- get the bundle id for the application name received as a parameter
+	set bundleId to id of application appName
+
+	tell application "Finder"
+		-- get Finder selected items
+		set theItems to selection
+		-- get the path for the applicaction with the bundle id defined above
+		set appPath to (POSIX path of (application file id bundleId as alias))
+	end tell
+
+	-- for each item in the Finder selection
+	repeat with itemRef in theItems
+		-- get the item path
+		set theItem to POSIX path of (itemRef as string)
+		-- set a shell command to open the item with the desired application
+		-- note:
+			-- opening the file with applescript often results in permission errors
+			-- but opening it with a shell script seems to bypass this issue
+		set command to "open -a " & quoted form of appPath & " " & quoted form of theItem
+		do shell script command
+	end repeat
+end run


### PR DESCRIPTION
## Description

<!-- Please write a short summary for this change. If it's a new script command, explain what it does. -->
Open selected items in Finder with the given application. 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New script command

## Screenshot

<!-- If it's a new script command, please include a screenshot or a GIF of how it works. -->

https://user-images.githubusercontent.com/365403/114734941-152ed280-9d1b-11eb-9d36-e5d5fc8bdf7d.mp4

## Dependencies / Requirements

<!-- If it's a new script command that requires some additional steps to make it work, please describe it here. E.g. requiring installation of another command line tool or requirement to specify username / API token / etc. -->

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)