### PR TITLE
Add script command: Show disk usage of / (root)

### DIFF
--- a/commands/system/disk-usage.sh
+++ b/commands/system/disk-usage.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Disk Usage
+# @raycast.mode inline
+# @raycast.refreshTime 1m
+
+# Optional parameters:
+# @raycast.icon 💿
+# @raycast.packageName System
+
+# Documentation:
+# @raycast.description Show disk usage for / (root)
+# @raycast.author Jesse Claven
+# @raycast.authorURL https://github.com/jesse-c
+
+# Example:
+#
+# Filesystem       Size   Used  Avail Capacity iused      ifree %iused  Mounted on
+# /dev/disk1s6s1  113Gi   15Gi  3.4Gi    82%  563983 1182278497    0%   /
+
+x=$(df -h / | awk 'FNR == 2 {printf "Root: %s available of %s",$4,$2;}')
+
+echo "$x"
+


### PR DESCRIPTION
## Description

Adds an inline script command to display the disk usage of your / (root).

It can relatively easily be adapted to a different disk, or even multiple disks.

## Type of change

- [x] New script command

## Screenshot

<img width="732" alt="image" src="https://user-images.githubusercontent.com/1405676/116010131-bfa4d080-a60c-11eb-9095-cee4bbb865f7.png">

## Dependencies / Requirements

N/A

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)