### PR TITLE
add "Empty Clipboard" command

### DIFF
--- a/commands/system/empty-clipboard.sh
+++ b/commands/system/empty-clipboard.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Empty Clipboard
+# @raycast.mode silent
+
+# Optional parameters:
+# @raycast.icon 📋
+# @raycast.packageName System
+
+# Documentation:
+# @raycast.description Empty Clipboard
+
+/usr/bin/pbcopy < /dev/null
+echo "Done"


### PR DESCRIPTION
## Description

It is a command to empty clipboard. Can be useful if you have some sensitive information in it and wanna it to be cleaned.

## Type of change

- [x] New script command

## Screenshot

<img width="862" alt="empty-clipboard" src="https://user-images.githubusercontent.com/53379023/116133992-0c091280-a6d8-11eb-9e4c-c864a5282a3b.png">

## Dependencies / Requirements

Nope

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)