### PR TITLE
changed "Empty Clipboard" output

### DIFF
--- a/commands/system/empty-clipboard.sh
+++ b/commands/system/empty-clipboard.sh
@@ -13,4 +13,4 @@
 # @raycast.description Empty Clipboard
 
 /usr/bin/pbcopy < /dev/null
-echo "Done"
+echo "Clipboard emptied"


### PR DESCRIPTION
## Description

Changed output of "Empty Clipboard" command to be consistent with "Empty Trash" in std

## Type of change

- [x] Improvement of an existing script

## Screenshot

## Dependencies / Requirements

nil

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)