### PR TITLE
Add SABnzbd queue status

### DIFF
--- a/commands/dashboard/sabnzbd-queue-status.template.sh
+++ b/commands/dashboard/sabnzbd-queue-status.template.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title SABnzbd Queue
+# @raycast.mode inline
+# @raycast.refreshTime 1m
+
+# Optional parameters:
+# @raycast.icon 🤖
+# @raycast.packageName Dashboard
+
+# Documentation:
+# @raycast.description Show SABnzbd's queue status
+# @raycast.author Jesse Claven
+# @raycast.authorURL https://github.com/jesse-c
+
+protocol="http"
+address="127.0.0.1"
+port="8080"
+apikey="<-- API KEY -->"
+
+full_queue_status=$(curl -s "$protocol://$address:$port/sabnzbd/api?output=json&apikey=$apikey&mode=queue")
+
+status=$(echo "$full_queue_status" | jq -j '.queue.status')
+size_left=$(echo "$full_queue_status" | jq -j '.queue.sizeleft')
+size=$(echo "$full_queue_status" | jq -j '.queue.size')
+speed=$(echo "$full_queue_status" | jq -j '.queue.speed')
+time_left=$(echo "$full_queue_status" | jq -j '.queue.timeleft')
+no_of_slots=$(echo "$full_queue_status" | jq -j '.queue.noofslots')
+
+if [ "$status" = "Paused" ]; then
+  time_left="-"
+  speed="-"
+fi
+
+echo "🚦 $status ・ 📥 $no_of_slots ・ ⏳ $time_left ・ 💿 $size_left / $size ・ 📊 $speed"


### PR DESCRIPTION
## Description

Displays some of the status points from the full queue status. To see what else is available, look at the [wiki](https://sabnzbd.org/wiki/advanced/api#queue).

## Type of change

- [x] New script command

## Screenshot

<img width="787" alt="image" src="https://user-images.githubusercontent.com/1405676/116789210-42121200-aa9d-11eb-901f-4eb0f5fac8d8.png">

<img width="770" alt="image" src="https://user-images.githubusercontent.com/1405676/116797682-e87b0900-aad7-11eb-9e25-59415e89a38e.png">

## Dependencies / Requirements

For users of [SABnzbd](https://sabnzbd.org/)

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)