### PR TITLE
translate-shell: Add script to translate into a favorite language-pair

### DIFF
--- a/commands/apps/translate-shell/translate-shell-language-pair.py
+++ b/commands/apps/translate-shell/translate-shell-language-pair.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+# -*- coding: UTF-8 -*-
+
+# Translate the query using translate-shell.
+# Allows to set a default language-pair that can be used to translate in both 
+# directions without setting the 'from' and 'to' languages.
+
+# Dependency: Requires translate-shell (https://www.soimort.org/translate-shell)
+# Install it with MacPorts: `sudo port install translate-shell`
+# Or with Homebrew: `brew install translate-shell`
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Translate Shell
+# @raycast.mode fullOutput
+
+# Optional parameters:
+# @raycast.argument1 {"type": "text", "placeholder": "Query"}
+# @raycast.argument2 {"type": "text", "placeholder": "from", "optional": true }
+# @raycast.argument3 {"type": "text", "placeholder": "to", "optional": true}
+# @raycast.icon 🌍
+
+# Documentation:
+# @raycast.author Marcel Bochtler
+# @raycast.authorURL https://github.com/MarcelBochtler
+# @raycast.description Translate text using translate-shell.
+
+# Set the default language pair.
+FROM_LANG_DEFAULT = 'de'
+TO_LANG_DEFAULT = 'en'
+
+# translate-shell requires gawk to be accessible from PATH.
+# This is not the case if the Homebrew prefix was customized or when using macports.
+# Add your PATH here, if required.
+PATH="$PATH"
+
+import json, os, sys, subprocess
+
+from_language = FROM_LANG_DEFAULT
+if sys.argv[2]:
+    from_language = sys.argv[2]
+
+to_language = TO_LANG_DEFAULT
+if sys.argv[3]:
+    to_language = sys.argv[3]
+
+colors = {
+  'green': '\033[92m',
+  'yellow': '\033[93m',
+  'red': '\033[91m',
+  'grey': '\033[90m',
+  'white': '\033[97m',
+  'end': '\033[0m',
+}
+
+def green(message):
+    return f"{colors['green']}{message}{colors['end']}"
+
+def yellow(message):
+    return f"{colors['yellow']}{message}{colors['end']}"
+
+def red(message):
+    return f"{colors['red']}{message}{colors['end']}"
+
+def grey(message):
+    return f"{colors['grey']}{message}{colors['end']}"
+
+def white(message):
+    return f"{colors['white']}{message}{colors['end']}"
+
+def translate(lang, query):
+    cmd = f"""
+    PATH="{PATH}"
+    trans '{lang}' -dump '{query}' | tail -n +2  | head -n -2
+    """
+
+    stream = os.popen(cmd)
+    rawJson = stream.read()
+
+    parsedJson = json.loads(rawJson)
+    translations = parsedJson[1]
+    if translations is not None:
+       translation = parsedJson[0][0][0]
+       subprocess.run("pbcopy", universal_newlines=True, input=translation)
+
+    return translations
+
+
+def print_translations(translations):
+    # TODO: Limit the number of translations so no scrolling in the results is required.
+    if translations is None:
+        print(yellow('No translations found.'))
+    else:
+        for i, translation in enumerate(translations):
+            wordType = translation[0]
+            print(grey(wordType))
+
+            translationWithBackTranslation = translation[2]
+            for j, t in enumerate(translationWithBackTranslation):
+                translatedWord = t[0]
+                backTranslations = t[1]
+                if i == 0 and j == 0:
+                    print(f'  {yellow(translatedWord)} 📋')
+                else:
+                    print(f'  {green(translatedWord)}')
+
+                print(white('    ' + ', '.join(backTranslations) + '\n'))
+
+
+query = sys.argv[1]
+translations = translate(f'{from_language}:{to_language}', query)
+
+if translations is None:
+    translations = translate(f'{to_language}:{from_language}', query)
+    # TODO: If second attempt failed, use result from first attempt and offer
+    #  a "Did you mean ..." functionality.
+    print_translations(translations)
+else:
+    print_translations(translations)

--- a/commands/apps/translate-shell/translate-shell-language-pair.py
+++ b/commands/apps/translate-shell/translate-shell-language-pair.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python3
 # -*- coding: UTF-8 -*-
 
-# Translate the query using translate-shell.
-# Allows to set a default language-pair that can be used to translate in both 
-# directions without setting the 'from' and 'to' languages.
-
 # Dependency: Requires translate-shell (https://www.soimort.org/translate-shell)
-# Install it with MacPorts: `sudo port install translate-shell`
-# Or with Homebrew: `brew install translate-shell`
+# Install with Homebrew: `brew install translate-shell`
+# or install with MacPorts: `sudo port install translate-shell`
+
+# translate-shell requires gawk to be accessible from PATH.
+# This is not the case if the Homebrew prefix was customized or when using macports.
+# Add your PATH here, if required.
+PATH="$PATH"
 
 # Required parameters:
 # @raycast.schemaVersion 1
@@ -26,13 +27,10 @@
 # @raycast.description Translate text using translate-shell.
 
 # Set the default language pair.
+# Allows to set a default language-pair that can be used to translate in both 
+# directions without setting the 'from' and 'to' languages.
 FROM_LANG_DEFAULT = 'de'
 TO_LANG_DEFAULT = 'en'
-
-# translate-shell requires gawk to be accessible from PATH.
-# This is not the case if the Homebrew prefix was customized or when using macports.
-# Add your PATH here, if required.
-PATH="$PATH"
 
 import json, os, sys, subprocess
 

--- a/commands/apps/translate-shell/translate-shell-language-pair.py
+++ b/commands/apps/translate-shell/translate-shell-language-pair.py
@@ -8,7 +8,7 @@
 # translate-shell requires gawk to be accessible from PATH.
 # This is not the case if the Homebrew prefix was customized or when using macports.
 # Add your PATH here, if required.
-PATH="$PATH"
+# PATH="$PATH"
 
 # Required parameters:
 # @raycast.schemaVersion 1

--- a/commands/apps/translate-shell/translate-to-en.sh
+++ b/commands/apps/translate-shell/translate-to-en.sh
@@ -16,7 +16,7 @@
 # Documentation:
 # @raycast.author tiancheng92
 # @raycast.authorURL https://github.com/tiancheng92
-# @raycast.description translate and copy brief translation to clipboard
+# @raycast.description Translate and copy brief translation to clipboard.
 
 if ! command -v trans &> /dev/null; then
 	echo "trans command is required (https://github.com/soimort/translate-shell).";

--- a/commands/apps/translate-shell/translate-to-zh.sh
+++ b/commands/apps/translate-shell/translate-to-zh.sh
@@ -16,7 +16,7 @@
 # Documentation:
 # @raycast.author tiancheng92
 # @raycast.authorURL https://github.com/tiancheng92
-# @raycast.description translate and copy brief translation to clipboard
+# @raycast.description Translate and copy brief translation to clipboard.
 
 if ! command -v trans &> /dev/null; then
 	echo "trans command is required (https://github.com/soimort/translate-shell).";

--- a/commands/web-searches/search-emojipedia.sh
+++ b/commands/web-searches/search-emojipedia.sh
@@ -2,7 +2,7 @@
 
 # Required parameters:
 # @raycast.schemaVersion 1
-# @raycast.title Search in emojipedia
+# @raycast.title Search in Emojipedia
 # @raycast.mode silent
 # @raycast.packageName Web Searches
 
@@ -11,7 +11,7 @@
 # @raycast.argument1 { "type": "text", "placeholder": "query", "percentEncoded": true}
 
 # Documentation:
-# @raycast.description Search for emojis at emojipedia
+# @raycast.description Search for emojis at emojipedia.
 # @raycast.author Benedict Neo
 # @raycast.authorURL https://github.com/benthecoder
 


### PR DESCRIPTION
## Description

This script lets the user configure a language-pair and uses it to
translate words for these languages in both directions.
The first result is copied to the clipboard.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New script command

## Screenshot

https://user-images.githubusercontent.com/4022103/117363464-e7255400-aebc-11eb-8de7-5721356d8821.mov

## Dependencies / Requirements

[Translate-Shell](https://www.soimort.org/translate-shell)

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)