### PR TITLE
Added a script that get the current connected airpods battery level

### DIFF
--- a/commands/system/audio/airpodsbattery.sh
+++ b/commands/system/audio/airpodsbattery.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Airpods Battery
+# @raycast.mode inline
+
+# Optional parameters:
+# @raycast.icon ⚡️
+# @raycast.packageName Audio
+# @raycast.refreshTime 10m
+
+# Documentation:
+# @raycast.description Get the current battery status of your Airpods.
+# @raycast.author Quentin Eude
+# @raycast.authorURL https://www.github.com/qeude
+
+OUTPUT=''
+BLUETOOTH_DEFAULTS=$(defaults read /Library/Preferences/com.apple.Bluetooth)
+SYSTEM_PROFILER=$(system_profiler SPBluetoothDataType 2>/dev/null)
+MAC_ADDR=$(grep -b2 "Minor Type: Headphones"<<<"${SYSTEM_PROFILER}"|awk '/Address/{print $3}')
+CONNECTED=$(grep -ia6 "${MAC_ADDR}"<<<"${SYSTEM_PROFILER}"|awk '/Connected: Yes/{print 1}')
+BLUETOOTH_DATA=$(grep -ia6 '"'"${MAC_ADDR}"'"'<<<"${BLUETOOTH_DEFAULTS}")
+BATTERY_LEVELS=("BatteryPercentCombined" "HeadsetBattery" "BatteryPercentSingle" "BatteryPercentCase" "BatteryPercentLeft" "BatteryPercentRight")
+LAST=${BATTERY_LEVELS[${#BATTERY_LEVELS[@]} - 1]}
+
+if [[ "${CONNECTED}" ]]; then
+    for I in "${BATTERY_LEVELS[@]}"; do
+        declare -x "${I}"="$(awk -v pat="${I}" '$0~pat{gsub (";",""); print $3 }'<<<"${BLUETOOTH_DATA}")"
+        if [[ $I == "BatteryPercentCase" && ${!I} == 0 ]]; then
+            continue
+        fi
+        if [[ $I == $LAST ]]; then
+            [[ -n "${!I}" ]] && OUTPUT="${OUTPUT} $(awk '/BatteryPercent/{print substr($0,15,5)}'<<<"${I}") ${!I}%"
+        else
+            [[ -n "${!I}" ]] && OUTPUT="${OUTPUT} $(awk '/BatteryPercent/{print substr($0,15,5)}'<<<"${I}") ${!I}% | "
+        fi
+    done
+    echo "${OUTPUT}"
+    exit 0
+else
+    echo "Not connected"
+    exit 0
+fi


### PR DESCRIPTION
## Description

Added a script that simply get the current connected AirPods battery level and display it.
It's refreshing automatically every 10min to avoid having to execute yourself/

## Type of change

- [x] New script command

## Screenshot

![Screen Recording 2021-05-08 at 12 18 58](https://user-images.githubusercontent.com/19294297/117535812-be55a980-aff7-11eb-85f9-789f58942a90.gif)

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)