### PR TITLE
Add 'Copy Current Page URL' for Google Chrome

### DIFF
--- a/commands/browsing/chrome-current-page-url.sh
+++ b/commands/browsing/chrome-current-page-url.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Copy Current Page URL
+# @raycast.mode silent
+# @raycast.packageName Google Chrome
+#
+# Optional parameters:
+# @raycast.icon 🧭
+#
+# Documentation:
+# @raycast.description This script copies URL of currently opened page in Google Chrome into clipboard.
+# @raycast.author Jakub Lanski
+# @raycast.authorURL https://github.com/jaklan
+
+osascript -e 'tell application "Google Chrome" to get URL of active tab of first window' | pbcopy
+echo "Copied"


### PR DESCRIPTION
## Description

Add 'Copy Current Page URL' for Google Chrome

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New script command
- [ ] Bug fix
- [ ] Improvement of an existing script
- [ ] Documentation update
- [ ] Toolkit change
- [ ] Other (Specify)

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)