### PR TITLE
Correct if statement and order of args in Google Maps

### DIFF
--- a/commands/google-maps/google-maps.sh
+++ b/commands/google-maps/google-maps.sh
@@ -14,10 +14,10 @@
 first_argument=${1// /+}
 second_argument=${2// /+}
 
-if [$1 == ""]; then
+if [ "$1" = "" ]; then
 	open "https://www.google.com/maps"
-elif [$2 == ""]; then
+elif [ "$2" = "" ]; then
 	open "https://www.google.com/maps/search/$first_argument"
 else
-	open "https://www.google.com/maps/dir/$second_argument/$first_argument"
+	open "https://www.google.com/maps/dir/$first_argument/$second_argument"
 fi


### PR DESCRIPTION
## Description

Correct if statement (lack of double quotes) and order of args (location and destination were in a wrong order) in Google Maps.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] New script command
- [x] Bug fix
- [ ] Improvement of an existing script
- [ ] Documentation update
- [ ] Toolkit change
- [ ] Other (Specify)

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)