### PR TITLE
Fix quote marks

### DIFF
--- a/commands/web-searches/search-pypi.sh
+++ b/commands/web-searches/search-pypi.sh
@@ -10,6 +10,6 @@
 # @raycast.packageName Web Searches
 # @raycast.schemaVersion 1
 
-# @raycast.argument1 { "type": "text", "placeholder": "Title", “percentEncoded”: true }
+# @raycast.argument1 { "type": "text", "placeholder": "Title", "percentEncoded": true }
 
 open "https://pypi.org/search/?q=${1}"

--- a/commands/web-searches/search-python3-docs.sh
+++ b/commands/web-searches/search-python3-docs.sh
@@ -10,6 +10,6 @@
 # @raycast.packageName Web Searches
 # @raycast.schemaVersion 1
 
-# @raycast.argument1 { "type": "text", "placeholder": "Title", “percentEncoded”: true }
+# @raycast.argument1 { "type": "text", "placeholder": "Title", "percentEncoded": true }
 
 open "https://docs.python.org/3/search.html?q=${1}"


### PR DESCRIPTION
## Description

Fix quote marks in both Python-related searches.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] New script command
- [x] Bug fix
- [ ] Improvement of an existing script
- [ ] Documentation update
- [ ] Toolkit change
- [ ] Other (Specify)

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)