### PR TITLE
[Bitwarden] Add quotes to query

### DIFF
--- a/commands/password-managers/bitwarden/copy-first-matching-password.sh
+++ b/commands/password-managers/bitwarden/copy-first-matching-password.sh
@@ -50,7 +50,7 @@ if [ $unlocked_status -ne 0 ]; then
   exit 1
 fi
 
-item=$(bw list items --search $1 $session 2> /dev/null | jq ".[0] | { name: .name, password: .login.password }")
+item=$(bw list items --search "$1" $session 2> /dev/null | jq ".[0] | { name: .name, password: .login.password }")
 name=$(echo $item | jq --exit-status ".name") || notFoundError
 password=$(echo $item | jq --raw-output --exit-status ".password") || notFoundError
 


### PR DESCRIPTION
## Description

Add quotes to login item query to properly handle names with spaces.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] New script command
- [x] Bug fix
- [ ] Improvement of an existing script
- [ ] Documentation update
- [ ] Toolkit change
- [ ] Other (Specify)

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)