### PR TITLE
Improvement of an existing script:create-new-file-in-finder.applescript

### DIFF
--- a/commands/system/create-new-file.applescript
+++ b/commands/system/create-new-file.applescript
@@ -1,0 +1,65 @@
+#!/usr/bin/osascript
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Create New File
+# @raycast.mode silent
+
+# Optional parameters:
+# @raycast.icon 📄
+
+# @Documentation:
+# @raycast.description Create files in the front window or desktop of the visit
+# @raycast.author LokHsu
+# @raycast.authorURL https://github.com/lokhsu
+
+set file_name to "untitled"
+set file_ext to ".txt"
+set is_desktop to false
+
+-- get folder path
+try
+    tell application "Finder"
+        set this_folder to folder of the front window as alias
+    end tell
+on error   -- no open folder windows
+    set this_folder to path to desktop folder as alias
+    set is_desktop to true
+end try
+
+-- get the new file name (do not override an already existing file)
+tell application "Finder"
+    set file_list to name of every file of this_folder
+end tell
+
+set new_file to file_name & file_ext
+set x to 1
+
+repeat
+    if new_file is in file_list then
+        set new_file to file_name & x & file_ext
+        set x to x + 1
+    else
+        exit repeat
+    end if
+end repeat
+
+-- create and select the new file
+tell application "Finder"
+    activate
+    set the_file to make new file at folder this_folder with properties {name:new_file}
+    if is_desktop is false then
+        reveal the_file
+    else
+        select window of desktop
+        set selection to the_file
+        delay 0.1
+    end if
+end tell
+
+-- press enter (rename)
+tell application "System Events"
+    tell process "Finder"
+    keystroke return
+    end tell
+end tell


### PR DESCRIPTION
## Description

<!-- Please write a short summary for this change. If it's a new script command, explain what it does. -->

  When I run '/script-commands/commands/system/create-new-file-in-finder.applescript' the file, I found a vulnerability: when the script is used to create a file in the folder, if the file "untitled.txt" with the same name already exists in the folder, the script will return an error prompt: "there is a file with the same name". 
  Therefore, based on the source file and according to my personal usage habits, I have made appropriate modifications to the part of the code that I think needs to be improved.

## Type of change

<!-- Please delete options that are not relevant. 

- [ ] -->

- [x] Improvement of an existing script

## Screenshot

<!-- If it's a new script command, please include a screenshot or a GIF of how it works. -->
![show](https://user-images.githubusercontent.com/71050409/118763207-099a7280-b8aa-11eb-90d0-6f161fe2acf9.GIF)

## Dependencies / Requirements

<!-- If it's a new script command that requires some additional steps to make it work, please describe it here. E.g. requiring installation of another command line tool or requirement to specify username / API token / etc. -->
 none.
## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)