### PR TITLE
Adding Finder command to open any location

### DIFF
--- a/commands/README.md
+++ b/commands/README.md
@@ -647,6 +647,7 @@ This repository contains sample commands and documentation to write your own one
   | 🌐 | [Open URL From Clipboard](navigation/open-url-from-clipboard.sh) | Opens the URL in the clipboard. | Raycast |  |  | <img src="images/icon-bash.png" width="20" height="20" title="Bash"> |
   | <img src="https://raw.githubusercontent.com/raycast/script-commands/master/commands/navigation/images/dash.png" width="20" height="20"> | [Search in Dash](navigation/search-in-dash.sh) | N/A | Jax0rz | ✅ |  | <img src="images/icon-bash.png" width="20" height="20" title="Bash"> |
   | <img src="https://raw.githubusercontent.com/raycast/script-commands/master/commands/navigation/images/devdocs.png" width="20" height="20"> | [Search in Devdocs](navigation/search-in-devdocs.sh) | N/A | Jax0rz | ✅ |  | <img src="images/icon-bash.png" width="20" height="20" title="Bash"> |
+  | 🔍 | [Open Finder](navigation/open-finder.sh) | Open Finder at $HOME or absolute path given | Afraz | ? |  | <img src="images/icon-bash.png" width="20" height="20" title="Bash"> |
 
 ## Password Managers
 

--- a/commands/navigation/open-finder.sh
+++ b/commands/navigation/open-finder.sh
@@ -7,7 +7,7 @@
 
 # Optional parameters:
 # @raycast.icon 🔍
-# @raycast.argument1 { "type": "text", "optional": true, "placeholder": "Placeholder" }
+# @raycast.argument1 { "type": "text", "optional": true, "placeholder": "Folder" }
 # @raycast.packageName Navigation
 
 # Documentation:

--- a/commands/navigation/open-finder.sh
+++ b/commands/navigation/open-finder.sh
@@ -13,6 +13,7 @@
 # Documentation:
 # @raycast.description Open Finder at $HOME or argument location
 # @raycast.author Afraz
+# @raycast.authorURL https://github.com/afrazkhan
 
 LOCATION=$1
 

--- a/commands/navigation/open-finder.sh
+++ b/commands/navigation/open-finder.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Open Finder
+# @raycast.mode silent
+
+# Optional parameters:
+# @raycast.icon 🔍
+# @raycast.argument1 { "type": "text", "optional": true, "placeholder": "Placeholder" }
+# @raycast.packageName open-finder
+
+# Documentation:
+# @raycast.description Open Finder at $HOME or argument location
+# @raycast.author Afraz
+
+LOCATION=$1
+
+if ! [[ "$LOCATION" =~ ^/ ]]; then
+  LOCATION="$HOME/$LOCATION"
+fi
+
+open "$LOCATION"

--- a/commands/navigation/open-finder.sh
+++ b/commands/navigation/open-finder.sh
@@ -8,7 +8,7 @@
 # Optional parameters:
 # @raycast.icon 🔍
 # @raycast.argument1 { "type": "text", "optional": true, "placeholder": "Placeholder" }
-# @raycast.packageName open-finder
+# @raycast.packageName Navigation
 
 # Documentation:
 # @raycast.description Open Finder at $HOME or argument location

--- a/commands/navigation/open-finder.sh
+++ b/commands/navigation/open-finder.sh
@@ -11,7 +11,7 @@
 # @raycast.packageName Navigation
 
 # Documentation:
-# @raycast.description Open Finder at $HOME or argument location
+# @raycast.description Open Finder at Home folder or argument location
 # @raycast.author Afraz
 # @raycast.authorURL https://github.com/afrazkhan
 


### PR DESCRIPTION
## Description

Adding a Finder command to open $HOME by default (no option given), or an absolute path if the argument starts with '/', or relative to $HOME if the argument doesn't start with '/'.

## Type of change

- [x] New script command

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)