### PR TITLE
Fix Toolkit that isn't retrieving the right createdDate and updatedDate for scripts

### DIFF
--- a/.github/workflows/script-commands.yml
+++ b/.github/workflows/script-commands.yml
@@ -2,7 +2,7 @@ name: Set as Executable and Generate Documentation
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
   scriptCommands:
@@ -10,6 +10,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - uses: maxim-lobanov/setup-xcode@v1
         with:


### PR DESCRIPTION
## Description

Currently the Toolkit isn't setting the right dates for scripts in the `extensions.json` file. These dates are retrieved from the git history via the git cli. The github's checkout action have a parameter `fetch-depth` with is set to 1 by default, this involves that git doesn’t get the full git log history. Setting it to 0 as should fix the history problem and then the weird behaviour of the command. :smile:

## Type of change

- [x] Bug fix
- [x] Toolkit change

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)