### PR TITLE
Add command to flush DNS cache

### DIFF
--- a/commands/system/flush-dns.sh
+++ b/commands/system/flush-dns.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Flush DNS
+# @raycast.mode silent
+# @raycast.packageName System
+
+# Optional parameters:
+# @raycast.icon 💨
+
+# Documentation:
+# @raycast.description Flush DNS cache
+# @raycast.author Felipe Turcheti
+# @raycast.authorURL https://felipeturcheti.com
+
+sudo dscacheutil -flushcache
+sudo killall -HUP mDNSResponder
+echo "DNS cache flushed"


### PR DESCRIPTION
## Description

<!-- Please write a short summary for this change. If it's a new script command, explain what it does. -->
Flushes macOS DNS cache.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New script command

## Screenshot

<!-- If it's a new script command, please include a screenshot or a GIF of how it works. -->
![Screen Shot 2021-06-10 at 10 18 07](https://user-images.githubusercontent.com/365403/121532242-8adeb400-c9d5-11eb-81f1-ab6651787cdb.png)

## Dependencies / Requirements

<!-- If it's a new script command that requires some additional steps to make it work, please describe it here. E.g. requiring installation of another command line tool or requirement to specify username / API token / etc. -->
None.

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)