### PR TITLE
Don't send blank args in x-callback-url

### DIFF
--- a/commands/apps/bear/bear-search.sh
+++ b/commands/apps/bear/bear-search.sh
@@ -16,4 +16,16 @@
 # @raycast.argument1 { "type": "text", "placeholder": "Term", "optional": true, "percentEncoded": true}
 # @raycast.argument2 { "type": "text", "placeholder": "Tag", "optional": true, "percentEncoded": true}
 
-open "bear://x-callback-url/search?term=${1}&tag=${2}"
+if [ ! -z "$1" ]; then
+  if [ ! -z "$2" ]; then
+    open "bear://x-callback-url/search?term=${1}&tag=${2}"
+  else
+    open "bear://x-callback-url/search?term=${1}"
+  fi
+else
+  if [ ! -z "$2" ]; then
+    open "bear://x-callback-url/search?tag=${2}"
+  else
+    open "bear://"
+  fi
+fi


### PR DESCRIPTION
## Description

Bear doesn't seem to like blank args in the `x-callback-url`, so only send the args that are supplied.

Specifically, if you specify a `term` but not a `tag`, Bear seems to not do a search at all. Sending only the `term` in the call results in correct search.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] New script command
- [x] Bug fix
- [x] Improvement of an existing script
- [ ] Documentation update
- [ ] Toolkit change
- [ ] Other (Specify)

## Screenshot

n/a

## Dependencies / Requirements

n/a

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)