### PR TITLE
Add character count command

### DIFF
--- a/commands/developer-utils/count-characters.py
+++ b/commands/developer-utils/count-characters.py
@@ -11,7 +11,7 @@
 # Optional parameters:
 # @raycast.icon 🤖
 # @raycast.argument1 { "type": "text", "placeholder": "Text", "optional": true }
-# @raycast.packageName Developer Utils
+# @raycast.packageName Developer Utilities
 
 # Documentation:
 # @raycast.description Counts the characters of either the clipboard or the passed argument

--- a/commands/developer-utils/count-characters.py
+++ b/commands/developer-utils/count-characters.py
@@ -5,7 +5,7 @@
 
 # Required parameters:
 # @raycast.schemaVersion 1
-# @raycast.title Count characters
+# @raycast.title Count Characters
 # @raycast.mode compact
 
 # Optional parameters:

--- a/commands/developer-utils/count-characters.py
+++ b/commands/developer-utils/count-characters.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+
+# Dependency: This script requires the python `pasteboard` library: https://github.com/tobywf/pasteboard
+# Install via pip: `pip install pasteboard`
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Count characters
+# @raycast.mode compact
+
+# Optional parameters:
+# @raycast.icon 🤖
+# @raycast.argument1 { "type": "text", "placeholder": "Text", "optional": true }
+# @raycast.packageName Developer Utils
+
+# Documentation:
+# @raycast.description Counts the characters of either the clipboard or the passed argument
+# @raycast.author Sven Bendel
+# @raycast.authorURL https://github.com/ubuntudroid
+
+import sys
+import pasteboard
+
+arg = sys.argv[1]
+
+if not arg:
+    pb = pasteboard.Pasteboard()
+    text = pb.get_contents()
+else:
+    text = arg
+
+print(str(len(text)) + " chars")


### PR DESCRIPTION
## Description

Counts the characters of either the clipboard or the passed argument.

## Type of change

- [x] New script command

## Screenshot

![CleanShot 2021-06-17 at 16 41 00](https://user-images.githubusercontent.com/519867/122419172-079c0000-cf8b-11eb-997e-a9cb100791eb.gif)

## Dependencies / Requirements

Needs python 3.x and the [pasteboard library](https://github.com/tobywf/pasteboard).

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)