### PR TITLE
Bitwarden: Fix issue that passwords with spaces were detected as invalid

### DIFF
--- a/commands/password-managers/bitwarden/unlock.sh
+++ b/commands/password-managers/bitwarden/unlock.sh
@@ -35,7 +35,7 @@ if ! command -v bw &> /dev/null; then
   exit 1
 fi
 
-out=$(bw --raw unlock $1)
+out=$(bw --raw unlock "$1")
 status=$?
 
 if [ $status -eq 0 ]; then


### PR DESCRIPTION
## Description
Fix issue that passwords with spaces were detected as invalid


## Type of change
- [x] Bug fix
- [x] Improvement of an existing script

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)