### PR TITLE
Bitwarden: Actually print an error message if no result was found

### DIFF
--- a/commands/password-managers/bitwarden/copy-first-matching-password.sh
+++ b/commands/password-managers/bitwarden/copy-first-matching-password.sh
@@ -22,7 +22,7 @@
 # @raycast.description Search all items in a Bitwarden vault, and copy the password of the first search result to the clipboard.
 
 notFound() {
-  echo "The query '$1' did not return a password."
+  echo "The query '${BASH_ARGV[0]}' did not return a password."
   exit 1
 }
 
@@ -51,8 +51,8 @@ if [ $unlocked_status -ne 0 ]; then
 fi
 
 item=$(bw list items --search "$1" $session 2> /dev/null | jq ".[0] | { name: .name, password: .login.password }")
-name=$(echo $item | jq --exit-status ".name") || notFoundError
-password=$(echo $item | jq --raw-output --exit-status ".password") || notFoundError
+name=$(echo $item | jq --exit-status ".name") || notFound
+password=$(echo $item | jq --raw-output --exit-status ".password") || notFound
 
 echo -n $password | pbcopy
 unset password


### PR DESCRIPTION
## Description

Notify the user if the searched password was not found.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] New script command
- [x] Bug fix
- [x] Improvement of an existing script
- [ ] Documentation update
- [ ] Toolkit change
- [ ] Other (Specify)

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)