### PR TITLE
TOTP support for Bitwarden

### DIFF
--- a/commands/password-managers/bitwarden/copy-first-matching-totp.sh
+++ b/commands/password-managers/bitwarden/copy-first-matching-totp.sh
@@ -50,7 +50,7 @@ if [ $unlocked_status -ne 0 ]; then
   exit 1
 fi
 
-totp=$(bw get totp "$1" $session)
+totp=$(bw get totp "$1" $session) || notFound
 echo -n $totp | pbcopy
 unset totp
 echo "Copied the TOTP for '$1' to the clipboard."

--- a/commands/password-managers/bitwarden/copy-first-matching-totp.sh
+++ b/commands/password-managers/bitwarden/copy-first-matching-totp.sh
@@ -3,8 +3,11 @@
 # Dependencies:
 #   1. The Bitwarden CLI: https://bitwarden.com/help/article/cli/
 #   2. The `jq` utility: https://stedolan.github.io/jq/
+#   3. Python3: https://programwithus.com/learn/python/install-python3-mac
+#   4. Python3 virtualenv: https://packaging.python.org/guides/installing-using-pip-and-virtual-environments/
 #
 # Install via homebrew: `brew install bitwarden-cli jq`
+# Follow instructions on steps 3-4
 
 # Required parameters:
 # @raycast.schemaVersion 1
@@ -24,7 +27,8 @@
 # Activate Python environment
 if ! command -v virtualenv &> /dev/null
 then
-    pip3 install virtualenv
+  echo "virtualenv command is required";
+  exit 1;
 fi
 
 if [ ! -d virtualenv ]; then
@@ -35,7 +39,7 @@ source venv/bin/activate
 
 if ! command -v mintotp &> /dev/null
 then
-    pip3 install mintotp
+    pip3 install mintotp # installs in virtualenv
 fi
 
 notFound() {

--- a/commands/password-managers/bitwarden/copy-first-matching-totp.sh
+++ b/commands/password-managers/bitwarden/copy-first-matching-totp.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+# Dependencies:
+#   1. The Bitwarden CLI: https://bitwarden.com/help/article/cli/
+#   2. The `jq` utility: https://stedolan.github.io/jq/
+#
+# Install via homebrew: `brew install bitwarden-cli jq`
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Copy First Matching TOTP
+# @raycast.mode silent
+#
+# Optional parameters:
+# @raycast.packageName Bitwarden
+# @raycast.icon images/bitwarden.png
+# @raycast.argument1 { "type": "text", "placeholder": "Query" }
+#
+# Documentation
+# @raycast.author Phil Salant
+# @raycast.authorURL https://github.com/PSalant726
+# @raycast.description Search all items in a Bitwarden vault, and copy the password of the first search result to the clipboard.
+
+# Activate Python environment
+if [ ! -d virtualenv ]; then
+  virtualenv venv
+fi
+
+source venv/bin/activate
+
+if ! command -v mintotp &> /dev/null
+then
+    pip3 install mintotp
+fi
+
+notFound() {
+  echo "The query '${BASH_ARGV[0]}' did not return a TOTP."
+  exit 1
+}
+
+if ! command -v bw &> /dev/null; then
+  echo "The Bitwarden CLI is not installed."
+  exit 1
+elif ! command -v jq &> /dev/null; then
+  echo "The jq utility is not installed."
+  exit 1
+fi
+
+token=$(security find-generic-password -a ${USER} -s raycast-bitwarden -w 2> /dev/null)
+token_status=$?
+
+session=""
+if [ $token_status -eq 0 ]; then
+  session="--session $token"
+fi
+
+bw unlock --check $session > /dev/null 2>&1
+unlocked_status=$?
+
+if [ $unlocked_status -ne 0 ]; then
+  echo "Vault is locked!"
+  exit 1
+fi
+
+item=$(bw list items --search "$1" $session 2> /dev/null | jq ".[0] | { name: .name, totp: .login.totp }")
+name=$(echo $item | jq --exit-status ".name") || notFound
+totp=$(echo $item | jq --raw-output --exit-status ".totp") || notFound
+totp=$(echo $totp | sed -E "s/^(.)+\?secret=//g" | sed -E "s/&issuer=(.)+//g") || notFound
+
+echo -n $(mintotp <<< $totp) | pbcopy
+unset totp
+echo "Copied the TOTP for '$name' to the clipboard."
+exit 0

--- a/commands/password-managers/bitwarden/copy-first-matching-totp.sh
+++ b/commands/password-managers/bitwarden/copy-first-matching-totp.sh
@@ -53,5 +53,5 @@ fi
 totp=$(bw get totp "$1" $session)
 echo -n $totp | pbcopy
 unset totp
-echo "Copied the TOTP for '$name' to the clipboard."
+echo "Copied the TOTP for '$1' to the clipboard."
 exit 0

--- a/commands/password-managers/bitwarden/copy-first-matching-totp.sh
+++ b/commands/password-managers/bitwarden/copy-first-matching-totp.sh
@@ -22,6 +22,11 @@
 # @raycast.description Search all items in a Bitwarden vault, and copy the password of the first search result to the clipboard.
 
 # Activate Python environment
+if ! command -v virtualenv &> /dev/null
+then
+    pip3 install virtualenv
+fi
+
 if [ ! -d virtualenv ]; then
   virtualenv venv
 fi


### PR DESCRIPTION
## Description

Adds TOTP clipboard support for the Bitwarden script command. Uses a Python3 library and virtualenv to avoid affecting the macOS packages.

## Type of change

- [x] New script command
- [x] Improvement of an existing script

## Screenshot

<img width="792" alt="image" src="https://user-images.githubusercontent.com/51373669/124965526-3b999c80-dff0-11eb-8843-594c2a3828bd.png">

## Dependencies / Requirements

No dependencies. macOS comes with Python 3. Installs virtualenv automatically, sets up the virtual environment, and then installs minitotp.

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)