### PR TITLE
Better link for new google meet

### DIFF
--- a/commands/communication/google-meet/meet.sh
+++ b/commands/communication/google-meet/meet.sh
@@ -9,7 +9,7 @@
 # @raycast.authorURL https://github.com/mujibazizi
 # @raycast.description Start a Google Meet session
 
-open https://meet.new
+open https://meet.google.com/new
 
 MAX_TRIES=10
 TRIES=0


### PR DESCRIPTION
## Description
Better URL to create a new Google Meet in the `communication/google-meet/meet.sh` script. The copied URL will look like `https://meet.google.com/xxx-xxxx-xxx` instead of `https://meet.google.com/xxx-xxxx-xxx?authuser=0`.

## Type of change
- [x] Improvement of an existing script

## Checklist
- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)