### PR TITLE
Add Script Command: Trim Git Commit Hash

### DIFF
--- a/commands/developer-utils/trim-git-commit-hash.sh
+++ b/commands/developer-utils/trim-git-commit-hash.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# @raycast.title Trim Git Commit Hash
+# @raycast.author Caleb Stauffer
+# @raycast.authorURL https://github.com/crstauf
+# @raycast.description Trim full git commit hash down to seven characters.
+
+# @raycast.icon ✂
+# @raycast.mode silent
+# @raycast.packageName Developer Utilities
+# @raycast.schemaVersion 1
+
+# @raycast.argument1 { "type": "text", "placeholder": "Full git commit hash" }
+
+str="$1"
+echo ${str:0:7} | tr -d '\n' | pbcopy


### PR DESCRIPTION
## Description

Accept parameter of full git commit hash and trim down to seven characters.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New script command

## Screenshot

<img width="768" alt="Screen Shot 2021-07-16 at 10 05 32 PM" src="https://user-images.githubusercontent.com/4573033/126022129-402bc611-13b3-442a-bca5-b7374dee7d61.png">

## Dependencies / Requirements

None

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)