### PR TITLE
Change "colour" to "color"

### DIFF
--- a/commands/system/sample-color.swift
+++ b/commands/system/sample-color.swift
@@ -2,7 +2,7 @@
 
 // Required parameters:
 // @raycast.schemaVersion 1
-// @raycast.title Sample Colour
+// @raycast.title Sample Color (Sample Colour)
 // @raycast.mode silent
 // @raycast.packageName System
 //
@@ -10,7 +10,7 @@
 // @raycast.icon 🎨
 //
 // Documentation:
-// @raycast.description Sample a colour from anywhere on your screen.
+// @raycast.description Sample a color from anywhere on your screen.
 // @raycast.author Jesse Claven
 // @raycast.authorURL https://github.com/jesse-c
 
@@ -30,9 +30,9 @@ extension NSColor {
   }
 }
 
-func copyToPasteboard(_ colour: String) {
+func copyToPasteboard(_ color: String) {
   NSPasteboard.general.clearContents()
-  NSPasteboard.general.writeObjects([colour as NSPasteboardWriting])
+  NSPasteboard.general.writeObjects([color as NSPasteboardWriting])
 }
 
 let sampler = NSColorSampler()
@@ -41,10 +41,10 @@ sampler.show { selectedColor in
   if let selectedColor = selectedColor {
     let hexTuple = selectedColor.hexAlphaString
     copyToPasteboard(hexTuple)
-    print("Sampled colour: \(hexTuple)")
+    print("Sampled color: \(hexTuple)")
     exit(0)
   } else {
-    print("Sampled colour: none")
+    print("Sampled color: none")
     exit(0)
   }
 }

--- a/commands/system/sample-color.swift
+++ b/commands/system/sample-color.swift
@@ -2,7 +2,7 @@
 
 // Required parameters:
 // @raycast.schemaVersion 1
-// @raycast.title Sample Color (Sample Colour)
+// @raycast.title Sample Color
 // @raycast.mode silent
 // @raycast.packageName System
 //


### PR DESCRIPTION


## Description

Swift uses "color", so I felt that using modifying it to be consistent would be better. Also, I renamed the title so that typing "sample color" or "sample colour" would work.

## Type of change

- [x] Improvement of an existing script

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)