### PR TITLE
Small improvements in Toolkit

### DIFF
--- a/Tools/Toolkit/Package.resolved
+++ b/Tools/Toolkit/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/apple/swift-argument-parser.git",
         "state": {
           "branch": null,
-          "revision": "92646c0cdbaca076c8d3d0207891785b3379cbff",
-          "version": "0.3.1"
+          "revision": "9564d61b08a5335ae0a36f789a7d71493eacadfc",
+          "version": "0.3.2"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/apple/swift-tools-support-core.git",
         "state": {
           "branch": null,
-          "revision": "31747ebaede7e1a1f2b15346790193d5b5e5e7be",
-          "version": "0.1.11"
+          "revision": "243beea77d20db46647a3de4765c96e2c801c7c7",
+          "version": "0.1.12"
         }
       }
     ]

--- a/Tools/Toolkit/Sources/ToolkitLibrary/Core/Toolkit/Toolkit+Constants.swift
+++ b/Tools/Toolkit/Sources/ToolkitLibrary/Core/Toolkit/Toolkit+Constants.swift
@@ -7,7 +7,7 @@ import Foundation
 import TSCBasic
 
 public extension Toolkit {
-  internal var blockedFolderList: [String] {
+  var blockedFolderList: [String] {
     [
       ".git",
       "screenshots",
@@ -18,6 +18,12 @@ public extension Toolkit {
       "images",
       "_enabled-commands",
       ".swiftpm",
+    ]
+  }
+
+  var blockedFilesExtensionsList: [String] {
+    [
+      "txt",
     ]
   }
 

--- a/Tools/Toolkit/Sources/ToolkitLibrary/Core/Toolkit/Toolkit+ReadContent.swift
+++ b/Tools/Toolkit/Sources/ToolkitLibrary/Core/Toolkit/Toolkit+ReadContent.swift
@@ -33,11 +33,20 @@ extension Toolkit {
         group.subGroups = subGroups
       }
 
-      parentGroups.append(group)
+      if values.isEmpty == false || subGroups.isEmpty == false {
+        parentGroups.append(group)
+      }
     }
 
-    for file in onlyFiles(at: path) {
+    let directoryFiles = onlyFiles(at: path)
+    for file in directoryFiles where directoryFiles.isEmpty == false {
       guard ignoreFilesInDir == false else {
+        continue
+      }
+
+      guard
+        let fileExtension = file.extension,
+        blockedFilesExtensionsList.contains(fileExtension) == false else {
         continue
       }
 
@@ -257,6 +266,19 @@ extension Toolkit {
       }
 
       if currentAuthor.keys.count == 2 {
+        guard let value = dictionary[key] as? String else {
+          continue
+        }
+
+        guard authors.contains(
+          where: {
+            $0[key] == value
+          }
+        ) == false else {
+          currentAuthor = [:]
+          continue
+        }
+
         authors.append(currentAuthor)
         currentAuthor = [:]
       }

--- a/Tools/Toolkit/Sources/ToolkitLibrary/Models/Language.swift
+++ b/Tools/Toolkit/Sources/ToolkitLibrary/Models/Language.swift
@@ -11,6 +11,7 @@ enum Language {
   case python
   case ruby
   case swift
+  case node
   case custom(String)
 
   init(_ rawValue: String) {
@@ -27,6 +28,8 @@ enum Language {
       self = .ruby
     case "swift":
       self = .swift
+    case "node", "js":
+      self = .node
     default:
       self = .custom(value)
     }
@@ -44,6 +47,8 @@ enum Language {
       return "icon-ruby.png"
     case .swift:
       return "icon-swift.png"
+    case .node:
+      return "icon-nodejs.png"
     default:
       return nil
     }
@@ -61,26 +66,15 @@ enum Language {
       return "Ruby"
     case .swift:
       return "Swift"
+    case .node:
+      return "Node"
     case .custom(let name):
       return name
     }
   }
 
   var name: String {
-    switch self {
-    case .applescript:
-      return "applescript"
-    case .bash:
-      return "bash"
-    case .python:
-      return "python"
-    case .ruby:
-      return "ruby"
-    case .swift:
-      return "swift"
-    case .custom(let name):
-      return name.lowercased()
-    }
+    displayName.lowercased()
   }
 }
 


### PR DESCRIPTION
## Description

Just few improvements in the Toolkit to make the generation of the README and the extensions.json even better

What was improved:
- [x] Add blocked file extensions list
- [x] Fix the detection of NodeJS scripts
- [x] Detect if the authorURL was already added (to avoid duplications)

## Type of change

- [ ] New script command
- [ ] Bug fix
- [ ] Improvement of an existing script
- [ ] Documentation update
- [x] Toolkit change
- [ ] Other (Specify)

## Checklist
- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)