### PR TITLE
New script to search notes via title

### DIFF
--- a/commands/apps/notes/open-note.applescript
+++ b/commands/apps/notes/open-note.applescript
@@ -2,7 +2,7 @@
 
 # Required parameters:
 # @raycast.schemaVersion 1
-# @raycast.title Search Notes
+# @raycast.title Open Note
 # @raycast.mode compact
 
 # Optional parameters:
@@ -11,12 +11,16 @@
 # @raycast.packageName Notes
 
 # Documentation:
-# @raycast.description Search for a Note by Title
+# @raycast.description Open Note via its Title
 # @raycast.author Vardan Sawhney
 # @raycast.authorURL https://github.com/commai
 
 on run argv
 	tell application "Notes"
-		show note (item 1 of argv)
+		if exists note (item 1 of argv)
+			show note (item 1 of argv)
+		else 
+			log "Sorry, the note \"" & (item 1 of argv) & "\" was not found" 
+		end if
 	end tell
 end run

--- a/commands/apps/notes/search-notes.applescript
+++ b/commands/apps/notes/search-notes.applescript
@@ -1,0 +1,22 @@
+#!/usr/bin/osascript
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Search Notes
+# @raycast.mode compact
+
+# Optional parameters:
+# @raycast.icon ./images/notes.png
+# @raycast.argument1 { "type": "text", "placeholder": "Note Title" }
+# @raycast.packageName Notes
+
+# Documentation:
+# @raycast.description Search for a Note by Title
+# @raycast.author Vardan Sawhney
+# @raycast.authorURL https://github.com/commai
+
+on run argv
+	tell application "Notes"
+		show note (item 1 of argv)
+	end tell
+end run


### PR DESCRIPTION
## Description

Simply allows you to search your notes via title. 

Note: titles need to be exact matches in order to query them properly and in the event that you have mutliple of the same titles, it'll choose the most recently edited one to display. 

## Type of change
- [x] New script command

## Screenshot
https://user-images.githubusercontent.com/46573539/127367109-8e84d725-2178-40c4-a1c4-0d68c13f325b.mov

## Dependencies / Requirements

No reqs/depedencies required. 

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)