### PR TITLE
adding force refresh script

### DIFF
--- a/commands/apps/safari/safari-clear-cache-reload.applescript
+++ b/commands/apps/safari/safari-clear-cache-reload.applescript
@@ -2,7 +2,7 @@
 
 # Required parameters:
 # @raycast.schemaVersion 1
-# @raycast.title Clear cache and refresh page
+# @raycast.title Clear Cache and Refresh Page
 # @raycast.mode silent
 #
 # Optional parameters:

--- a/commands/apps/safari/safari-clear-cache-reload.applescript
+++ b/commands/apps/safari/safari-clear-cache-reload.applescript
@@ -1,0 +1,18 @@
+#!/usr/bin/osascript
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Clear cache and refresh page
+# @raycast.mode silent
+#
+# Optional parameters:
+# @raycast.packageName Safari
+# @raycast.icon images/safari.png
+#
+# Documentation:
+# @raycast.description This script clears cache and reloads the page of the frontmost Safari window.
+# @raycast.author Aaron Miller
+# @raycast.authorURL https://github.com/aaronhmiller
+
+tell application "Safari" to activate
+tell application "System Events" to keystroke "r" using {option down, command down} --warning: undocumented can change w/o notice


### PR DESCRIPTION
## Description

This script use the option-command-R keyboard shortcut to force refresh a Safari page. It arose out of a need to get a current CI badge status when using Github Action workflows because I noticed that the badge would not reflect the current status unless cache was cleared and the page refreshed. Normally that requires enabling Developer Menu and opt-cmd-E and cmd-R, but opt-cmd-R seems to do both and doesn't require enabling Developer Mode. Having this in Raycast is just one less thing to remember and it's nice to have it stored centrally.

## Type of change

- [X] New script command

## Screenshot

Not much to see here...it just force refreshes the frontmost safari page. I added a comment about this being undocumented and therefore subject to change w/o notice. 

## Dependencies / Requirements

none

## Checklist

- [X] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)