### PR TITLE
Create Apple Music Search script command

### DIFF
--- a/commands/media/apple-music/apple-music-search.applescript
+++ b/commands/media/apple-music/apple-music-search.applescript
@@ -56,7 +56,6 @@ on run argv
 		tell application "System Events" to keystroke "0" using command down
 	end if
 	
-	log "Trying to search " & ({item 1 of argv} as text)
 	delay 0.1
 	tell application "System Events"
 		keystroke "f" using command down
@@ -66,4 +65,5 @@ on run argv
 	end tell
 	delay 5
 	set the clipboard to savedClipboard
+	log "Done"
 end run

--- a/commands/media/apple-music/apple-music-search.applescript
+++ b/commands/media/apple-music/apple-music-search.applescript
@@ -18,7 +18,14 @@
 on run argv
 	set savedClipboard to the clipboard
 	set the clipboard to ({item 1 of argv} as text)
-	do shell script "open /System/Applications/Music.app"
+	try
+		do shell script "open /System/Applications/Music.app"
+		tell application "Music" to activate
+	end try
+	try
+	do shell script "open /Applications/iTunes.app"
+		tell application "iTunes" to activate
+	end try
 	
 	# Argh, the window title varies... Add your language if it's not here...
 	set musicWindow to {"Music", "ミュージック", "音乐", "音樂"}

--- a/commands/media/apple-music/apple-music-search.applescript
+++ b/commands/media/apple-music/apple-music-search.applescript
@@ -1,0 +1,56 @@
+#!/usr/bin/osascript
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Search Apple Music
+# @raycast.mode compact
+
+# Optional parameters:
+# @raycast.icon images/apple-music-logo.png
+# @raycast.argument1 { "type": "text", "placeholder": "searching..." }
+# @raycast.packageName Apple Music Search
+
+# Documentation:
+# @raycast.description Search using the native UI
+# @raycast.author StevenRCE0
+# @raycast.authorURL https://github.com/StevenRCE0
+
+on run argv
+	do shell script "open /System/Applications/Music.app"
+	
+	# Argh, the window title varies... Add your language if it's not here...
+	set musicWindow to {"Music", "ミュージック", "音乐", "音樂"}
+	set notShowing to true
+	
+	# Thanks StactOverflow user mklement0 for the code below detecting window name ;-)
+	# Tell the *process* to count its windows and return its front window's name.
+	tell application "System Events"
+		# Get the frontmost app's *process* object.
+		set frontAppProcess to first application process whose frontmost is true
+	end tell
+	tell frontAppProcess
+		if (count of windows) > 0 then
+			set window_name to name of front window
+			if window_name is in musicWindow then
+				set notShowing to false
+			end if
+		end if
+	end tell
+	if notShowing is true then
+		tell application "System Events" to keystroke "0" using command down
+	end if
+	
+	log "Trying to search " & {item 1 of argv}
+	set savedClipboard to the clipboard
+	set the clipboard to ({item 1 of argv} as text)
+	delay 0.1
+	tell application "System Events"
+		keystroke "f" using command down
+		keystroke "a" using command down
+		key code 51
+		keystroke "v" using command down
+		key code 36
+	end tell
+	delay 0.1
+	set the clipboard to savedClipboard
+end run

--- a/commands/media/apple-music/apple-music-search.applescript
+++ b/commands/media/apple-music/apple-music-search.applescript
@@ -16,11 +16,20 @@
 # @raycast.authorURL https://github.com/StevenRCE0
 
 on run argv
+	set savedClipboard to the clipboard
+	set the clipboard to ({item 1 of argv} as text)
 	do shell script "open /System/Applications/Music.app"
 	
 	# Argh, the window title varies... Add your language if it's not here...
 	set musicWindow to {"Music", "ミュージック", "音乐", "音樂"}
 	set notShowing to true
+	set toLaunch to true
+
+	repeat while toLaunch
+		if application "Music" is running then set toLaunch to false
+		if application "iTunes" is running then set toLaunch to false
+		delay 0.5
+	end repeat
 	
 	# Thanks StactOverflow user mklement0 for the code below detecting window name ;-)
 	# Tell the *process* to count its windows and return its front window's name.
@@ -40,17 +49,14 @@ on run argv
 		tell application "System Events" to keystroke "0" using command down
 	end if
 	
-	log "Trying to search " & {item 1 of argv}
-	set savedClipboard to the clipboard
-	set the clipboard to ({item 1 of argv} as text)
+	log "Trying to search " & ({item 1 of argv} as text)
 	delay 0.1
 	tell application "System Events"
 		keystroke "f" using command down
 		keystroke "a" using command down
-		key code 51
 		keystroke "v" using command down
 		key code 36
 	end tell
-	delay 0.1
+	delay 5
 	set the clipboard to savedClipboard
 end run

--- a/commands/media/apple-music/apple-music-search.applescript
+++ b/commands/media/apple-music/apple-music-search.applescript
@@ -8,7 +8,7 @@
 # Optional parameters:
 # @raycast.icon images/apple-music-logo.png
 # @raycast.argument1 { "type": "text", "placeholder": "Artist or Music" }
-# @raycast.packageName Apple Music Search
+# @raycast.packageName Apple Music
 
 # Documentation:
 # @raycast.description Search using the native UI

--- a/commands/media/apple-music/apple-music-search.applescript
+++ b/commands/media/apple-music/apple-music-search.applescript
@@ -7,7 +7,7 @@
 
 # Optional parameters:
 # @raycast.icon images/apple-music-logo.png
-# @raycast.argument1 { "type": "text", "placeholder": "searching..." }
+# @raycast.argument1 { "type": "text", "placeholder": "Artist or Music" }
 # @raycast.packageName Apple Music Search
 
 # Documentation:

--- a/commands/media/apple-music/apple-music-search.applescript
+++ b/commands/media/apple-music/apple-music-search.applescript
@@ -3,7 +3,7 @@
 # Required parameters:
 # @raycast.schemaVersion 1
 # @raycast.title Search Apple Music
-# @raycast.mode compact
+# @raycast.mode silent
 
 # Optional parameters:
 # @raycast.icon images/apple-music-logo.png

--- a/commands/media/apple-music/apple-music-search.applescript
+++ b/commands/media/apple-music/apple-music-search.applescript
@@ -2,7 +2,7 @@
 
 # Required parameters:
 # @raycast.schemaVersion 1
-# @raycast.title Search Apple Music
+# @raycast.title Search
 # @raycast.mode silent
 
 # Optional parameters:


### PR DESCRIPTION
## Description

This is a script that operates directly on the Music/iTunes app interface. 

It's actually doing copy-and-paste so it replaces your clipboard for a few seconds and then restores it. This enables inputting more languages than keystrokes. 

## Type of change

- [x] New script command

## Screenshot

https://user-images.githubusercontent.com/40051361/129825589-bdee76f9-9597-4a5d-87e3-19d03b18b3d1.mov

## Requirements

The script detects the window's title to determine whether you're in the library view so that it could handle it while you have the mini-player opened or there's no window. However, the title varies depending on the app's language and I haven't actually tested it with iTunes. **Please add the window's title to the array in the script file if it doesn't work.** 

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)