### PR TITLE
Added command to resolve short urls

### DIFF
--- a/commands/developer-utils/unshorten-url.sh
+++ b/commands/developer-utils/unshorten-url.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Unshorten URL
+# @raycast.author Nikita Galaiko
+# @raycast.authorURL https://github.com/ngalaiko
+# @raycast.mode silent
+# @raycast.packageName Developer Utilities
+
+# Optional parameters:
+# @raycast.icon 🔗
+
+# Documentation:
+# @raycast.description Unshortens clipboard content url and copies the result again.
+
+## Please note that https://unshorten.me has a limit of unique 10 requests per hour:
+## https://unshorten.me/api
+
+function resolve() {
+    local url_short="${1//+/ }"
+    local schema_less="$(sed 's/https\{0,1\}:\/\///g' <<<"${url_short}")"
+    local resolved="$(curl --silent https://unshorten.me/s/${schema_less})"
+    printf '%b' "${resolved//%/\\x}"
+}
+
+resolve $(pbpaste) | pbcopy
+echo "URL resolved"


### PR DESCRIPTION
## Description

This PR adds a Developer Util to resolve short URLs. I personally find it useful since most of short url services are blocked in my home network. 

## Type of change

- [x] New script command
- [ ] Bug fix
- [ ] Improvement of an existing script
- [ ] Documentation update
- [ ] Toolkit change
- [ ] Other (Specify)

## Screenshot

![sgpv2uTeFD](https://user-images.githubusercontent.com/15010292/129930303-9d78f589-f71b-4474-acc4-998b7d59b2cf.gif)

## Dependencies / Requirements

This script depends on https://unshorten.me/api

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)