### PR TITLE
Added command to upload latest screenshot to Imgur

### DIFF
--- a/commands/productivity/imgur-upload-latest-screenshot.template.sh
+++ b/commands/productivity/imgur-upload-latest-screenshot.template.sh
@@ -1,20 +1,13 @@
 #!/bin/bash
 
-# Upload Latest Screenshot to Imgur
-# Fahim Faisal
-# Code is free to use. Do whatever you want with it
-
 # Required parameters:
 # @raycast.schemaVersion 1
 # @raycast.title Upload Latest Screenshot to Imgur
 # @raycast.mode silent
 # @raycast.packageName Upload to Imgur
-
 #
 # Optional parameters:
 # @raycast.icon ☁️
-# @raycast.currentDirectoryPath ~
-# @raycast.needsConfirmation false
 #
 # Documentation:
 # @raycast.description Upload your last screenshot to Imgur and copy the image link to clipboard
@@ -27,8 +20,13 @@ DIR=$(defaults read com.apple.screencapture location)
 FILE=$(ls -t "$DIR" | head -n 1)
 FILELOC="$DIR/$FILE"
 
-#Client ID, use your own to avoid limits. Get from https://api.imgur.com/oauth2/addclient
-client_id="6b1da49ab5fce27"
+#Client ID, use your own client ID. Get it from https://api.imgur.com/oauth2/addclient (Select anonymous useage as auth type)
+client_id="" #CAN NOT BE EMPTY
+
+if [ "$client_id" == "" ]; then
+    echo "No API Key found. Configure your own key before running"
+    exit -1
+fi
 
 function upload {
 	curl -s -H "Authorization: Client-ID $client_id" -H "Expect: " -F "image=$1" https://api.imgur.com/3/image.xml

--- a/commands/productivity/last2imgur.sh
+++ b/commands/productivity/last2imgur.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# Upload Latest Screenshot to Imgur
+# Fahim Faisal
+# Code is free to use. Do whatever you want with it
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Upload Latest Screenshot to Imgur
+# @raycast.mode silent
+# @raycast.packageName Upload to Imgur
+
+#
+# Optional parameters:
+# @raycast.icon ☁️
+# @raycast.currentDirectoryPath ~
+# @raycast.needsConfirmation false
+#
+# Documentation:
+# @raycast.description Upload your last screenshot to Imgur and copy the image link to clipboard
+# @raycast.author Fahim Faisal
+# @raycast.authorURL https://github.com/i3p9
+
+
+# Get screenshot location and latest screenshot
+DIR=$(defaults read com.apple.screencapture location)
+FILE=$(ls -t "$DIR" | head -n 1)
+FILELOC="$DIR/$FILE"
+
+#Client ID, use your own to avoid limits. Get from https://api.imgur.com/oauth2/addclient
+client_id="6b1da49ab5fce27"
+
+function upload {
+	curl -s -H "Authorization: Client-ID $client_id" -H "Expect: " -F "image=$1" https://api.imgur.com/3/image.xml
+}
+
+output=$(upload "@$FILELOC") 2>/dev/null
+
+if echo "$output" | grep -q 'success="0"'; then
+    echo "From Imgur: Upload Error, try again" >&2
+else
+    #grab the image link and delete hash from curl response
+    url="${output##*<link>}"
+    url="${url%%</link>*}"
+    delete_hash="${output##*<deletehash>}"
+    delete_hash="${delete_hash%%</deletehash>*}"
+
+    #Copy to clipboard
+    echo -n "$url" | pbcopy
+    echo "Link copied to clipboard"
+fi


### PR DESCRIPTION
## Description
It's a very simple script command that uploads the latest screenshot to Imgur and copies the image link to clipboard.
<!-- Please write a short summary for this change. If it's a new script command, explain what it does. -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New script command

## Screenshot
![](https://i.imgur.com/a6oZVnw.gif)
<!-- If it's a new script command, please include a screenshot or a GIF of how it works. -->

## Dependencies / Requirements
Uploading to Imgur does require an API, I have created an application and put the client id, you can put your own API as well . Imgur allows for 1.25k images per day for free api so you might want to use your own depending on your use-case. [Imgur API](https://api.imgur.com/oauth2/addclient)
<!-- If it's a new script command that requires some additional steps to make it work, please describe it here. E.g. requiring installation of another command line tool or requirement to specify username / API token / etc. -->

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)