### PR TITLE
Open current Safari URL in a different browser

### DIFF
--- a/commands/apps/safari/safari-current-page-url-in-chrome.applescript
+++ b/commands/apps/safari/safari-current-page-url-in-chrome.applescript
@@ -1,0 +1,22 @@
+#!/usr/bin/osascript
+
+# @raycast.title Open Safari URL in Chrome
+# @raycast.description Open current Safari URL in new tab in Chrome
+# @raycast.author Dave Lehman
+# @raycast.authorURL https://github.com/dlehman
+
+# @raycast.icon images/safari.png
+# @raycast.mode silent
+# @raycast.packageName System
+# @raycast.schemaVersion 1
+
+tell application "Safari"
+	set safariUrl to URL of front document
+end tell
+
+tell application "Google Chrome"
+	activate
+	delay 0.5
+	tell front window to make new tab at after (get active tab) with properties {URL:safariUrl} -- open a new tab after the current tab
+	activate
+end tell

--- a/commands/apps/safari/safari-current-page-url-in-chrome.applescript
+++ b/commands/apps/safari/safari-current-page-url-in-chrome.applescript
@@ -7,7 +7,7 @@
 
 # @raycast.icon images/safari.png
 # @raycast.mode silent
-# @raycast.packageName System
+# @raycast.packageName Safari
 # @raycast.schemaVersion 1
 
 tell application "Safari"

--- a/commands/apps/safari/safari-current-page-url-in-firefox.applescript
+++ b/commands/apps/safari/safari-current-page-url-in-firefox.applescript
@@ -1,0 +1,22 @@
+#!/usr/bin/osascript
+
+# @raycast.title Open Safari URL in Firefox
+# @raycast.description Open current Safari URL in new tab in Firefox
+# @raycast.author Dave Lehman
+# @raycast.authorURL https://github.com/dlehman
+
+# @raycast.icon images/safari.png
+# @raycast.mode silent
+# @raycast.packageName System
+# @raycast.schemaVersion 1
+
+tell application "Safari"
+	set safariUrl to URL of front document
+end tell
+
+tell application "Firefox"
+	activate
+	delay 0.5
+	open location safariUrl
+	activate
+end tell

--- a/commands/apps/safari/safari-current-page-url-in-firefox.applescript
+++ b/commands/apps/safari/safari-current-page-url-in-firefox.applescript
@@ -7,7 +7,7 @@
 
 # @raycast.icon images/safari.png
 # @raycast.mode silent
-# @raycast.packageName System
+# @raycast.packageName Safari
 # @raycast.schemaVersion 1
 
 tell application "Safari"


### PR DESCRIPTION
## Description

Open the URL of the current page in Safari in a different browser (Chrome or Firefox).

## Type of change

- [X] New script command

## Screenshot

Self explanatory.

## Dependencies / Requirements

None.

## Checklist

- [X] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)