### PR TITLE
Fix google translate

### DIFF
--- a/commands/web-searches/google-translate.rb
+++ b/commands/web-searches/google-translate.rb
@@ -35,7 +35,14 @@ if q.length < 2
     exit 1
 end
 
-uri = URI("https://translate.googleapis.com/translate_a/single?client=gtx&sl=#{sl}&tl=#{tl}&dt=t&q=#{q}")
+uri = URI('https://translate.googleapis.com/translate_a/single')
+uri.query = URI::encode_www_form(
+  'client' => 'gtx',
+  'sl' => sl,
+  'tl' => tl,
+  'dt' => 't',
+  'q' => q
+)
 
 http = Net::HTTP.new(uri.host, 80)
 request = Net::HTTP::Get.new(uri, initheader = {'Content-Type' => 'application/json', 'Accept' => 'application/json'})


### PR DESCRIPTION
## Description

This PR fixes two issues in the existing [google-translate script](https://github.com/raycast/script-commands/blob/master/commands/web-searches/google-translate.rb).

1. The default argument check only tested for empty strings, I added a check for null values as well to make it more robust.
2. The translation query was not escaped, so that words containing non ASCII characters couldn't be translated (such as "Oberfläche").

## Type of change

- [x] Bug fix
- [x] Improvement of an existing script

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)