### PR TITLE
Added Open URL in iOS Simulator script

### DIFF
--- a/commands/developer-utils/open-link-simulator.applescript
+++ b/commands/developer-utils/open-link-simulator.applescript
@@ -1,0 +1,22 @@
+#!/usr/bin/osascript
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Open Deep Link
+# @raycast.mode compact
+
+# Optional parameters:
+# @raycast.argument1 { "type": "text", "placeholder": "Deep link" }
+
+# Documentation:
+# @raycast.description Opens a URL inside the currently booted iOS Simulator. Can be used to open deeplinks
+# @raycast.author Tomás Martins
+# @raycast.authorURL https://github.com/tfmart
+# @raycast.icon 🔗
+
+# @raycast.packageName Developer Utilities
+# @raycast.schemaVersion 1
+
+on run argv
+	do shell script "xcrun simctl openurl booted " & (item 1 of argv)
+end run

--- a/commands/developer-utils/open-link-simulator.applescript
+++ b/commands/developer-utils/open-link-simulator.applescript
@@ -6,7 +6,7 @@
 # @raycast.mode compact
 
 # Optional parameters:
-# @raycast.argument1 { "type": "text", "placeholder": "Deep link" }
+# @raycast.argument1 { "type": "text", "placeholder": "Deep Link" }
 
 # Documentation:
 # @raycast.description Opens a URL inside the currently booted iOS Simulator. Can be used to open deeplinks


### PR DESCRIPTION
## Description

Very excited to be sharing my first script with the community 🎉 

This script open the inputted URL on the iOS simulator that is currently booted, which also includes URL Schemes and Universal Links. This has been really handy when I need to test a deep link in my apps

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New script command
- [ ] Bug fix
- [ ] Improvement of an existing script
- [ ] Documentation update
- [ ] Toolkit change
- [ ] Other (Specify)

## Screenshot

![Gravação de Tela 2021-08-31 às 18 04 22](https://user-images.githubusercontent.com/23082132/131575932-2ec03b5a-61ba-4518-9759-b224be0a9f45.gif)

## Dependencies / Requirements

<!-- If it's a new script command that requires some additional steps to make it work, please describe it here. E.g. requiring installation of another command line tool or requirement to specify username / API token / etc. -->

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)