### PR TITLE
Fix curl request and return link to clipboard instead of JSON respons…

### DIFF
--- a/commands/productivity/imgur/imgur-upload-clipboard-image.template.sh
+++ b/commands/productivity/imgur/imgur-upload-clipboard-image.template.sh
@@ -43,7 +43,7 @@ fi
 
 
 function upload {
-	curl -s -H "Authorization: Client-ID $client_id" -H "Expect: " -F "image=$1" https://api.imgur.com/3/image.xml
+	curl --location --request POST 'https://api.imgur.com/3/image' --header "Authorization: Client-ID $client_id" --form "image=$1"
 }
 
 #Grab full file path from clipboard if there's an image
@@ -75,8 +75,8 @@ if echo "$output" | grep -q 'success="0"'; then
 elif echo "$output" | grep -q 'Imgur is over capacity!'; then
     echo "From Imgur: Upload Error, try again" >&2
 else
-    url="${output##*<link>}"
-    url="${url%%</link>*}"
+    url="${output##*\"link\":\"}"
+    url="${url%%\"\}*}"
     delete_hash="${output##*<deletehash>}"
     delete_hash="${delete_hash%%</deletehash>*}"
 

--- a/commands/productivity/imgur/imgur-upload-latest-screenshot.template.sh
+++ b/commands/productivity/imgur/imgur-upload-latest-screenshot.template.sh
@@ -29,7 +29,7 @@ if [ "$client_id" == "" ]; then
 fi
 
 function upload {
-	curl -s -H "Authorization: Client-ID $client_id" -H "Expect: " -F "image=$1" https://api.imgur.com/3/image.xml
+	curl --location --request POST 'https://api.imgur.com/3/image' --header "Authorization: Client-ID $client_id" --form "image=$1"
 }
 
 output=$(upload "@$FILELOC") 2>/dev/null
@@ -38,8 +38,8 @@ if echo "$output" | grep -q 'success="0"'; then
     echo "From Imgur: Upload Error, try again" >&2
 else
     #grab the image link and delete hash from curl response
-    url="${output##*<link>}"
-    url="${url%%</link>*}"
+    url="${output##*\"link\":\"}"
+    url="${url%%\"\}*}"
     delete_hash="${output##*<deletehash>}"
     delete_hash="${delete_hash%%</deletehash>*}"
 

--- a/commands/productivity/imgur/screenshot-and-imgur.sh
+++ b/commands/productivity/imgur/screenshot-and-imgur.sh
@@ -24,7 +24,7 @@ if [ "$client_id" == "" ]; then
 fi
 
 function upload {
-	curl -s -H "Authorization: Client-ID $client_id" -H "Expect: " -F "image=$1" https://api.imgur.com/3/image.xml
+	curl --location --request POST 'https://api.imgur.com/3/image' --header "Authorization: Client-ID $client_id" --form "image=$1"
 }
 
 #Opens screenshot interface
@@ -41,8 +41,8 @@ if echo "$output" | grep -q 'success="0"'; then
 elif echo "$output" | grep -q 'Imgur is over capacity!'; then
     echo "From Imgur: Upload Error, try again" >&2
 else
-    url="${output##*<link>}"
-    url="${url%%</link>*}"
+    url="${output##*\"link\":\"}"
+    url="${url%%\"\}*}"
     delete_hash="${output##*<deletehash>}"
     delete_hash="${delete_hash%%</deletehash>*}"
 


### PR DESCRIPTION
…e object

## Description

The previous curl request was returning an "invalid clientID" error and targeting an endpoint that had changed in the latest Imgur docs. The endpoint has been updated and the error has disappeared.

Next, on a successful response, the script was copying the entire JSON response object to your clipboard, when the desired behavior is to copy only the URL. This behavior has also been fixed.

## Type of change

- [x] Bug fix
- [x] Improvement of an existing script

## Screenshot

## Dependencies / Requirements

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)