### PR TITLE
[Document fix] use workaround for header collision in Spotify

### DIFF
--- a/commands/README.md
+++ b/commands/README.md
@@ -101,7 +101,7 @@ This repository contains sample commands and documentation to write your own one
   - [Apple Music](#apple-music)
   - [Apple Tv](#apple-tv)
   - [Cmus](#cmus)
-  - [Spotify](#spotify)
+  - [Spotify](#spotify-1)
 - [Navigation](#navigation)
 - [Password Managers](#password-managers)
   - [Bitwarden](#bitwarden)


### PR DESCRIPTION
## Description
- The link for Media>Spotify is wrongly pointing to App>Spotify
## Type of change
- [x] Documentation update
## Checklist
- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)