### PR TITLE
Add script to generate markdown tables from column + row input

### DIFF
--- a/commands/conversions/create-markdown-table.js
+++ b/commands/conversions/create-markdown-table.js
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+
+// Required parameters:
+// @raycast.schemaVersion 1
+// @raycast.title Markdown Table
+// @raycast.packageName Utils
+// @raycast.mode silent
+
+// Optional parameters:
+// @raycast.icon 🧱
+// @raycast.argument1 { "type": "text", "placeholder": "Columns" }
+// @raycast.argument2 { "type": "text", "placeholder": "Rows" }
+
+// Documentation:
+// @raycast.description Create a markdown table template
+// @raycast.author Ryan Nystrom
+// @raycast.authorURL https://github.com/rnystrom
+
+const child_process = require("child_process");
+
+function pbcopy(data) {
+  return new Promise(function (resolve, reject) {
+    const child = child_process.spawn("pbcopy");
+
+    child.on("error", function (err) {
+      reject(err);
+    });
+
+    child.on("close", function (err) {
+      resolve(data);
+    });
+
+    child.stdin.write(data);
+    child.stdin.end();
+  });
+}
+
+let [columns, rows] = process.argv.slice(2);
+columns = Math.max(parseInt(columns), 1);
+rows = Math.max(parseInt(rows), 1);
+
+let emptyTemplate = "   ";
+let headerTemplate = "---";
+let rowArr = Array(columns + 1).fill("|");
+
+let lines = [];
+
+// header
+lines.push(rowArr.join(emptyTemplate));
+// header spacer |---|
+lines.push(rowArr.join(headerTemplate));
+
+// rows
+for (let i = 0; i < rows; i++) {
+  lines.push(rowArr.join(emptyTemplate));
+}
+
+pbcopy(lines.join("\n"));

--- a/commands/conversions/create-markdown-table.js
+++ b/commands/conversions/create-markdown-table.js
@@ -6,7 +6,7 @@
 // Required parameters:
 // @raycast.schemaVersion 1
 // @raycast.title Markdown Table
-// @raycast.packageName Utils
+// @raycast.packageName Conversions
 // @raycast.mode silent
 
 // Optional parameters:

--- a/commands/conversions/create-markdown-table.js
+++ b/commands/conversions/create-markdown-table.js
@@ -1,5 +1,8 @@
 #!/usr/bin/env node
 
+// Dependency: This script requires Nodejs.
+// Install Node: https://nodejs.org/en/download/
+
 // Required parameters:
 // @raycast.schemaVersion 1
 // @raycast.title Markdown Table


### PR DESCRIPTION
## Description

<!-- Please write a short summary for this change. If it's a new script command, explain what it does. -->

Adds a new script that enables creating a markdown table from column & row inputs. I used to love this script with Alfred, bringing it over to Raycast.

Simply input something like `table 3 2` to copy to clipboard:

```
|   |   |   |
|---|---|---|
|   |   |   |
|   |   |   |
```

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New script command
- [ ] Bug fix
- [ ] Improvement of an existing script
- [ ] Documentation update
- [ ] Toolkit change
- [ ] Other (Specify)

## Screenshot

<!-- If it's a new script command, please include a screenshot or a GIF of how it works. -->

<img width="886" alt="Screen Shot 2021-10-14 at 5 10 03 PM" src="https://user-images.githubusercontent.com/739696/137395924-496e76f1-87bb-4eb6-bfa0-5e65b3a57654.png">


## Dependencies / Requirements

<!-- If it's a new script command that requires some additional steps to make it work, please describe it here. E.g. requiring installation of another command line tool or requirement to specify username / API token / etc. -->

Node

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)