### PR TITLE
Fix `audio-output-switch` for Monterey

### DIFF
--- a/commands/system/audio/audio-output-switch.template.applescript
+++ b/commands/system/audio/audio-output-switch.template.applescript
@@ -22,6 +22,8 @@ tell application "System Preferences"
 
 	reveal anchor "output" of pane id "com.apple.preference.sound"
 	
+	delay 1
+	
 	tell application "System Events"
 		tell process "System Preferences"
 			select (row 1 of table 1 of scroll area 1 of tab group 1 of window "Sound" whose value of text field 1 is asrc)


### PR DESCRIPTION
## Description

It was brought to my attention by @dehesa that the `audio-output-switch` script I created was no longer working in macOS Monterey. From what I gathered it seems the error occurs due to the fact that Monterey now displays "Loading Sound..." for a moment while the preference pane is populated. Adding a simple 1 second delay to the script seems to fix the issue for me.

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)