### PR TITLE
feat: random-number script command

### DIFF
--- a/commands/math/random-number.sh
+++ b/commands/math/random-number.sh
@@ -10,8 +10,6 @@
 #
 # Optional parameters:
 # @raycast.icon 🔢
-# @raycast.currentDirectoryPath ~
-# @raycast.needsConfirmation false
 #
 # Documentation:
 # @raycast.description Generate a number between a given range (inclusive) and then copy the value

--- a/commands/math/random-number.sh
+++ b/commands/math/random-number.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Generate Random Number
+# @raycast.mode silent
+# @raycast.packageName Math
+# @raycast.argument1 { "type": "text", "placeholder": "0"}
+# @raycast.argument2 { "type": "text", "placeholder": "0"}
+#
+# Optional parameters:
+# @raycast.icon 🔢
+# @raycast.currentDirectoryPath ~
+# @raycast.needsConfirmation false
+#
+# Documentation:
+# @raycast.description Generate a number between a given range (inclusive) and then copy the value
+# @raycast.author Matt Gleich
+# @raycast.authorURL https://mattglei.ch
+
+VALUE=$(jot -r 1 $1 $2)
+echo $VALUE | pbcopy
+
+echo "Copied value of" $VALUE

--- a/commands/math/random-number.sh
+++ b/commands/math/random-number.sh
@@ -5,8 +5,8 @@
 # @raycast.title Generate Random Number
 # @raycast.mode silent
 # @raycast.packageName Math
-# @raycast.argument1 { "type": "text", "placeholder": "0"}
-# @raycast.argument2 { "type": "text", "placeholder": "0"}
+# @raycast.argument1 { "type": "text", "placeholder": "From"}
+# @raycast.argument2 { "type": "text", "placeholder": "To"}
 #
 # Optional parameters:
 # @raycast.icon 🔢


### PR DESCRIPTION
Signed-off-by: Matt Gleich <git@mattglei.ch>

## Description

This script-command allows the user to generate a number between a given range quickly

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New script command
- [ ] Bug fix
- [ ] Improvement of an existing script
- [ ] Documentation update
- [ ] Toolkit change
- [ ] Other (Specify)

## Screenshot

https://user-images.githubusercontent.com/43759105/141932900-d38b2af1-a3f6-44d0-b21d-29db52e10dbd.mov

## Dependencies / Requirements

`jot` and `pbcopy` are included by default in macOS

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)