### PR TITLE
Add script to place call via Apple's Cellular Calls feature

### DIFF
--- a/commands/communication/call-with-iphone.sh
+++ b/commands/communication/call-with-iphone.sh
@@ -11,7 +11,7 @@
 # @raycast.packageName Communication
 
 # Documentation:
-# @raycast.description Place a telephone call via your iPhone on wifi.
+# @raycast.description Place a telephone call via your iPhone on Wi-Fi.
 # @raycast.author Alexander JH Steffen
 # @raycast.authorURL https://github.com/alexjsteffen
 

--- a/commands/communication/call-with-iphone.sh
+++ b/commands/communication/call-with-iphone.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Call with iPhone
+# @raycast.mode compact
+
+# Optional parameters:
+# @raycast.icon 📱
+# @raycast.argument1 { "type": "text", "placeholder": "+1 514 555 1212" }
+# @raycast.packageName Call
+
+# Documentation:
+# @raycast.description Place a telephone call via your iPhone on wifi.
+# @raycast.author Alexander JH Steffen
+# @raycast.authorURL https://github.com/alexjsteffen
+
+sleep 1
+open "tel://$1"
+
+

--- a/commands/communication/call-with-iphone.sh
+++ b/commands/communication/call-with-iphone.sh
@@ -8,7 +8,7 @@
 # Optional parameters:
 # @raycast.icon 📱
 # @raycast.argument1 { "type": "text", "placeholder": "+1 514 555 1212" }
-# @raycast.packageName Call
+# @raycast.packageName Communication
 
 # Documentation:
 # @raycast.description Place a telephone call via your iPhone on wifi.


### PR DESCRIPTION
Add a basic script using the native Cellular Call Feature provided by Apple. There is no easy way to make a normal telephone call other than using the Contacts app or FaceTime (although the UX for this feature has gotten worse in Monterey. 

See: https://support.apple.com/en-ca/HT209456 

## Description

This script uses the "iPhone Cellular Call Feature" provided by apple to quickly make telephone calls without having to go via Contacts. Added one second of sleep to allow an individual to consider whether it was a mistake. It happens.

## Type of change

- [ ] New script command

## Screenshot

As simple as can be:

![Demo](https://user-images.githubusercontent.com/52205871/144958411-73b94102-e0fe-4bc0-930a-09d3941e6c17.gif)


## Dependencies / Requirements

None. 


## Checklist

- [ ] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md) - Yes