### PR TITLE
Change `c-like` to `cpp`

### DIFF
--- a/commands/developer-utils/create-image-from-code.sh
+++ b/commands/developer-utils/create-image-from-code.sh
@@ -23,7 +23,7 @@ BACKGROUND="true"
 DARK_MODE="true"
 # Set padding. Available options: 16, 32, 64 or 128
 PADDING="64"
-# Set language. Available options: shell, c-like (C++), csharp, clojure, coffeescript, crystal, css, d, dart, diff, dockerfile, elm, erlang, fortran, gherkin,
+# Set language. Available options: shell, cpp (C/C++), csharp, clojure, coffeescript, crystal, css, d, dart, diff, dockerfile, elm, erlang, fortran, gherkin,
 # go, groovy, haskell, xml, java, javascript, json, jsx, julia, kotlin, latex, lisp, lua, markdown, mathematica, octave, nginx, objectivec, ocaml (F#), perl, php,
 # powershell, python, r, ruby, rust, scala, smalltalk, sql, swift, typescript, (for Tsx, use jsx), twig, verilog, vhdl, xquery, yaml
 LANGUAGE="auto"


### PR DESCRIPTION
## Description

`language=c-like` doesn't work, replace by `language=cpp`

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] New script command
- [x] Bug fix
- [x] Improvement of an existing script
- [ ] Documentation update
- [ ] Toolkit change
- [ ] Other (Specify)

## Screenshot

<!-- If it's a new script command, please include a screenshot or a GIF of how it works. -->

## Dependencies / Requirements

<!-- If it's a new script command that requires some additional steps to make it work, please describe it here. E.g. requiring installation of another command line tool or requirement to specify username / API token / etc. -->

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)