### PR TITLE
Fix DeepL app translate script for app v3

### DIFF
--- a/commands/apps/deepl/deepl-app-translate.applescript
+++ b/commands/apps/deepl/deepl-app-translate.applescript
@@ -47,7 +47,7 @@ on run translate
 	end if
 	
 	tell application "System Events"
-		set value of text area 1 of group 4 of UI Element 1 of scroll area 1 of group 1 of group 1 of window "DeepL" of process "DeepL" to inputText
+		set value of text area 1 of group 3 of UI Element 1 of scroll area 1 of group 1 of group 1 of window "DeepL" of process "DeepL" to inputText
 	end tell
 	
 	if copyResultToClipboard is true then


### PR DESCRIPTION
## Description

DeepL app translate was not working after upgrading to version 3.0 because the gui changed slightly

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)