### PR TITLE
add command template for creating a reminder on slack

### DIFF
--- a/commands/communication/slack/add-slack-reminder.template.sh
+++ b/commands/communication/slack/add-slack-reminder.template.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# API: https://api.slack.com/methods/reminders.add
+
+# Parameters
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Add Reminder
+# @raycast.mode silent
+
+# Optional parameters:
+# @raycast.packageName Slack
+# @raycast.icon ⏰
+# @raycast.argument1 { "type": "text", "placeholder": "What" }
+# @raycast.argument2 { "type": "text", "placeholder": "When" }
+
+# Documentation:
+# @raycast.description Create a Slack reminder
+# @raycast.author Zeb Pykosz
+# @raycast.authorURL https://github.com/zebapy
+
+# Configuration
+
+# To create a new API token, do the following:
+# 1. Create a new Slack app at https://api.slack.com/authentication/basics
+# 2. Add `reminders:write` to the user token scopes
+# 3. Install the app to your workplace
+# 4. Insert your OAuth access token below
+API_TOKEN=""
+
+if [[ -z "$API_TOKEN" ]]
+then 
+  echo "No API token provided"
+  exit 1
+fi
+
+RESPONSE=$(
+curl \
+  --header "Content-Type: application/json" \
+  --header "Authorization: Bearer $API_TOKEN" \
+  --request POST \
+  --data "{ 'text': '$1', 'time': '$2' }" \
+  --silent \
+  --output /dev/null \
+  --show-error \
+  --fail \
+  "https://slack.com/api/reminders.add"
+)
+
+if [[ "$RESPONSE" =~ "error" ]]
+then
+  echo "Failed to add reminder in Slack"
+  exit 1
+else 
+  echo "Added reminder '$1 $2' in Slack!"
+  exit 0
+fi


### PR DESCRIPTION
## Description

Adds a new script command bash template for creating a reminder on slack using their reminders endpoint

https://api.slack.com/methods/reminders.add

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New script command
- [ ] Bug fix
- [ ] Improvement of an existing script
- [ ] Documentation update
- [ ] Toolkit change
- [ ] Other (Specify)

## Screenshot

https://user-images.githubusercontent.com/2199845/149343775-abe8681b-a0e3-42bb-b640-e02fcff6f3e6.mov

![Screen Shot 2022-01-13 at 8 56 24 AM](https://user-images.githubusercontent.com/2199845/149343948-0210aacb-7aa6-4f68-8104-d3cfe659966a.png)

Then see your reminders in slack with `/remind list` command

![Screen Shot 2022-01-13 at 8 56 11 AM](https://user-images.githubusercontent.com/2199845/149343951-c57f8c88-ca15-4722-b1ab-98474fc82dfd.png)

Your new reminder should show up! 

<!-- If it's a new script command, please include a screenshot or a GIF of how it works. -->

## Dependencies / Requirements

<!-- If it's a new script command that requires some additional steps to make it work, please describe it here. E.g. requiring installation of another command line tool or requirement to specify username / API token / etc. -->

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)