### PR TITLE
Improve relaunch Finder in toggle-desktop-icons(system)

### DIFF
--- a/commands/system/toggle-desktop-icons.applescript
+++ b/commands/system/toggle-desktop-icons.applescript
@@ -26,8 +26,20 @@ end if
 
 do shell script "defaults write com.apple.finder CreateDesktop -bool " & NewSet
 
-tell application "Finder"
-  quit
+tell application "Finder" to quit
+
+set inTime to current date
+repeat
+    -- check Finder process not exist
+    tell application "System Events"
+        if "Finder" is not in (get name of processes) then exit repeat
+    end tell
+    -- if repeat run for 10s, exit repeat
+    if (current date) - inTime is greater than 10 then exit repeat
+    delay 0.2
+end repeat
+
+tell application "Finder" 
   try
     activate
   end try


### PR DESCRIPTION
## Description
Wait the Finder process not exit after quit Finder, then activate Finder, otherwise activate will always failed.

<!-- Please write a short summary for this change. If it's a new script command, explain what it does. -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] New script command
- [ ] Bug fix
- [x] Improvement of an existing script
- [ ] Documentation update
- [ ] Toolkit change
- [ ] Other (Specify)

## Screenshot

<!-- If it's a new script command, please include a screenshot or a GIF of how it works. -->

## Dependencies / Requirements

<!-- If it's a new script command that requires some additional steps to make it work, please describe it here. E.g. requiring installation of another command line tool or requirement to specify username / API token / etc. -->

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)