### PR TITLE
Fix copy ip blank space

### DIFF
--- a/commands/developer-utils/ip/get-external-ip-v4.sh
+++ b/commands/developer-utils/ip/get-external-ip-v4.sh
@@ -13,5 +13,5 @@
 # @raycast.description Copies the external IPv4 to the clipboard.
 
 ip=$(curl -4 -s -m 5 https://api.ipify.org)
-echo $ip | pbcopy
+echo $ip | tr -d '\n' | pbcopy
 echo "Copied $ip"

--- a/commands/developer-utils/ip/get-external-ip-v6.sh
+++ b/commands/developer-utils/ip/get-external-ip-v6.sh
@@ -13,5 +13,5 @@
 # @raycast.description Copies the external IPv6 to the clipboard.
 
 ip=$(curl -6 -s -m 5 https://api64.ipify.org)
-echo $ip | pbcopy
+echo $ip | tr -d '\n' | pbcopy
 echo "Copied $ip"

--- a/commands/developer-utils/ip/get-local-ip-v4.sh
+++ b/commands/developer-utils/ip/get-local-ip-v4.sh
@@ -14,5 +14,5 @@
 
 ip=$(ifconfig | grep 'inet.*broadcast' | awk '{print $2}')
 IFS=' ' read -ra array <<< "$ip"
-echo ${array[0]} | pbcopy
+echo ${array[0]} | tr -d '\n' | pbcopy
 echo "Copied $ip"

--- a/commands/developer-utils/ip/get-local-ip-v6.sh
+++ b/commands/developer-utils/ip/get-local-ip-v6.sh
@@ -14,5 +14,5 @@
 
 ip=$(ifconfig | grep 'inet6.*%en' | awk '{print $2}')
 IFS=' ' read -ra array <<< "$ip"
-echo ${array[0]} | pbcopy
+echo ${array[0]} | tr -d '\n' | pbcopy
 echo "Copied $ip"


### PR DESCRIPTION
## Description

These ip script were copying the ip with a space at the end; 'xx.xx.xxx.xx ', fixed that so there is no more blank space at the end.

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Improvement of an existing script

## Dependencies / Requirements

None

## Checklist

- [X] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)