### PR TITLE
Add a note about removing ".template"

### DIFF
--- a/commands/system/audio/toggle-airpods.template.swift
+++ b/commands/system/audio/toggle-airpods.template.swift
@@ -16,6 +16,8 @@
 
 import IOBluetooth
 
+// Note: This a template which needs further setup. Remove `.template.` from the filename.
+
 // Get your device's MAC address by option (⌥) + clicking the bluetooth icon in the menu bar
 let deviceAddress = ""
 


### PR DESCRIPTION
## Description

It took me some time to figure out that I need to remove the `.template` part of the name when I'm done with the script set up. This PR adds a simple comment in the script's file to remind users of the script to remove the `.template` part.

## Type of change

- [x] Improvement of an existing script

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)