### PR TITLE
feat: latex-calculator script command

### DIFF
--- a/commands/math/latex-calculator.py
+++ b/commands/math/latex-calculator.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title LaTeX Calculator
+# @raycast.mode silent
+# @raycast.packageName Math
+#
+# Optional parameters:
+# @raycast.icon 🧮
+# @raycast.argument1 { "type": "text", "placeholder": "\\frac{4}{2}}", "optional": true}
+#
+# Documentation:
+# @raycast.description Evaluate LaTeX expressions and get the product copied to your clipboard
+# @raycast.author Matt Gleich
+# @raycast.authorURL https://mattglei.ch
+
+import pyperclip
+from sympy.parsing.latex import parse_latex
+import sys
+
+result = float(parse_latex(sys.argv[1]).evalf())
+
+if result.is_integer():
+    result = round(result)
+
+pyperclip.copy(result)
+print(f"Copied {result} to clipboard")
+


### PR DESCRIPTION
Signed-off-by: Matt Gleich <git@mattglei.ch>

## Description

Allow the user to input a LaTeX math expression and have the evaluated product be copied to their clipboard.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New script command
- [ ] Bug fix
- [ ] Improvement of an existing script
- [ ] Documentation update
- [ ] Toolkit change
- [ ] Other (Specify)

## Screenshot

https://user-images.githubusercontent.com/43759105/152477036-0e2acf17-b633-4536-a8df-516a348b9bcc.mov

## Dependencies / Requirements

This script command requires pyperclip, sympy, and antlr4-python3-runtime. They can all be installed using the following commands:

```bash
pip3 install pyperclip
pip3 install sympy
pip3 install antlr4-python3-runtime==4.7.2
```

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)