### PR TITLE
add product id for airpods 3rd gen

### DIFF
--- a/commands/system/audio/airpodsbattery.sh
+++ b/commands/system/audio/airpodsbattery.sh
@@ -16,7 +16,7 @@
 # @raycast.authorURL https://www.github.com/qeude
 
 # This should be changed every time new AirPods models are released.
-airpods_product_ids=("0x200E" "0x200F" "0x2002")
+airpods_product_ids=("0x200E" "0x200F" "0x2002" "0x2013")
 airpods_max_product_ids=("0x200A")
 delimiter="    🎧    "
 


### PR DESCRIPTION
## Description

Fix the `system/audio/airpodsbattery.sh` not working with AirPods 3rd gen.

## Type of change

- [ ] New script command
- [x] Bug fix
- [ ] Improvement of an existing script
- [ ] Documentation update
- [ ] Toolkit change
- [ ] Other (Specify)

## Screenshot

N/A

## Dependencies / Requirements

N/A

## Checklist

N/A

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)