### PR TITLE
system/audio/airpodsbatter.sh: add product id for airpods 3rd gen

### DIFF
--- a/commands/system/audio/airpodsbattery.sh
+++ b/commands/system/audio/airpodsbattery.sh
@@ -16,7 +16,7 @@
 # @raycast.authorURL https://www.github.com/qeude
 
 # This should be changed every time new AirPods models are released.
-airpods_product_ids=("0x200E" "0x200F" "0x2002")
+airpods_product_ids=("0x200E" "0x200F" "0x2002" "0x2013")
 airpods_max_product_ids=("0x200A")
 delimiter="    🎧    "
 


### PR DESCRIPTION
## Description

Fix the `system/audio/airpodsbattery.sh` extension to work properly with AirPods 3rd gen.

## Type of change

- [x] Bug fix

## Screenshot


Before

![image](https://user-images.githubusercontent.com/4350401/152899823-58d97dbd-15a0-45c8-8a84-f4da7d1f043f.png)

After

![image](https://user-images.githubusercontent.com/4350401/152899854-cf95d409-2820-4e18-b23b-dbbf19c9f76c.png)


## Dependencies / Requirements

N/A

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)