### PR TITLE
Allowed conversion from CamelCase to snake_case in the `snakecase.py` script

### DIFF
--- a/commands/conversions/change-case/snakecase.py
+++ b/commands/conversions/change-case/snakecase.py
@@ -17,6 +17,7 @@
 # @raycast.description Change to clipboard text to snake case
 
 import subprocess
+import re
 
 def getClipboardData():
     p = subprocess.Popen(["pbpaste"], stdout=subprocess.PIPE)
@@ -30,6 +31,7 @@ def setClipboardData(data):
     p.stdin.close()
 
 clipboard = str(getClipboardData())
-result = clipboard.lower().replace(" ", "_").replace("-", "_")
+result = re.sub(r"([a-z])([A-Z])", r"\1_\2", clipboard)
+result = result.lower().replace(" ", "_").replace("-", "_")
 setClipboardData(result)
 print(result)


### PR DESCRIPTION
## Description

The original snake_case script converted `CamelCaseExample` to `camelcaseexample`. This PR fixes the problem so `CamelCaseExample` correctly becomes `camel_case_example`.

## Type of change

- [x] Improvement of an existing script

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)