### PR TITLE
Add close all Finder windows command.

### DIFF
--- a/commands/system/close-finder-windows.applescript
+++ b/commands/system/close-finder-windows.applescript
@@ -1,0 +1,17 @@
+#!/usr/bin/osascript
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Close all currently open Finder windows.
+# @raycast.mode silent
+# @raycast.packageName Navigation
+#
+# Optional parameters:
+# @raycast.icon 🔪
+#
+# Documentation:
+# @raycast.description Close all open Finder windows. They add up. 
+# @raycast.author Alexander Steffen
+# @raycast.authorURL https://github.com/alexjsteffen
+
+tell application "Finder" to close windows

--- a/commands/system/close-finder-windows.applescript
+++ b/commands/system/close-finder-windows.applescript
@@ -2,15 +2,15 @@
 
 # Required parameters:
 # @raycast.schemaVersion 1
-# @raycast.title Close all currently open Finder windows.
+# @raycast.title Close All Finder Windows
 # @raycast.mode silent
-# @raycast.packageName Navigation
+# @raycast.packageName System
 #
 # Optional parameters:
 # @raycast.icon 🔪
 #
 # Documentation:
-# @raycast.description Close all open Finder windows. They add up. 
+# @raycast.description Close all open Finder windows. 
 # @raycast.author Alexander Steffen
 # @raycast.authorURL https://github.com/alexjsteffen
 


### PR DESCRIPTION
## Description

As you may know, it is not easy to close multiple open Finder windows without using the Finder-specific keyboard shortcut. This AppleScript will close all windows while keeping other apps open and Finder without forcing Finder to close and reopen.

## Type of change

- [ ] New script command

## Screenshot

![demo](https://user-images.githubusercontent.com/52205871/153990854-24e96948-da48-4abf-9fb7-4b585adb77a1.gif)

## Dependencies / Requirements

None

## Checklist

- [X] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)