### PR TITLE
Paste as plain text

### DIFF
--- a/commands/conversions/paste-as-plain-text.sh
+++ b/commands/conversions/paste-as-plain-text.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Paste as Plain Text
+# @raycast.mode silent
+
+# Optional parameters:
+# @raycast.icon 📋
+# @raycast.packageName Conversions
+
+# Documentation:
+# @raycast.author Michael Bianco
+# @raycast.authorURL https://github.com/iloveitaly
+
+pbpaste | pbcopy
+osascript -e 'tell application "System Events" to keystroke "v" using command down'


### PR DESCRIPTION
## Description

Coming from Alfred, this was one of the things I was missing. This is a simple
script that can be invoked to paste a string without any formatting.

## Type of change

- [x] New script command

## Screenshot

https://user-images.githubusercontent.com/150855/154361647-7d153c9b-141b-4237-b8ee-b400ccf146b4.mp4

## Dependencies / Requirements

N/A

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)
