### PR TITLE
[Hyper] Fix Hyper integration

### DIFF
--- a/commands/apps/hyper/hyper-run-shell-command.applescript
+++ b/commands/apps/hyper/hyper-run-shell-command.applescript
@@ -14,6 +14,7 @@
 
 # Optional parameters:
 # @raycast.icon images/hyper.png
+# @raycast.currentDirectoryPath ~
 # @raycast.argument1 { "type": "text", "placeholder": "Command" }
 
 # Documentation:


### PR DESCRIPTION
## Description

Add `# @raycast.currentDirectoryPath ~` to the applescript, because without it, the script can't find `./.hyper_plugins/hyperalfred.txt`

No, I can't use `~/.hyper_plugins/hyperalfred.txt` because the script returns a permissions error

## Type of change

- [x] Bug fix
- [x] Improvement of an existing script

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)