### PR TITLE
Safari: Strip whitespace when copying current page URL

### DIFF
--- a/commands/browsing/safari-current-page-url.sh
+++ b/commands/browsing/safari-current-page-url.sh
@@ -14,5 +14,5 @@
 # @raycast.author Kirill Gorbachyonok
 # @raycast.authorURL https://github.com/japanese-goblinn
 
-osascript -e 'tell application "Safari" to return URL of front document' | pbcopy
-echo "Copied"
+osascript -e 'tell application "Safari" to return URL of front document' | tr -d '[:space:]' | pbcopy
+echo "Copied URL"


### PR DESCRIPTION
## Description

Strips whitespace when copying current Safari page URL.

## Type of change

- [x] Improvement of an existing script

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)