### PR TITLE
add: add battery info script command

### DIFF
--- a/commands/system/battery-info.sh
+++ b/commands/system/battery-info.sh
@@ -4,7 +4,7 @@
 # @raycast.schemaVersion 1
 # @raycast.title Battery Info
 # @raycast.mode inline
-# @raycast.refreshTime 1s
+# @raycast.refreshTime 3m
 # @raycast.packageName System
 
 #

--- a/commands/system/battery-info.sh
+++ b/commands/system/battery-info.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Battery Info
+# @raycast.mode inline
+# @raycast.refreshTime 1s
+# @raycast.packageName System
+
+#
+# Optional parameters:
+# @raycast.icon 🔋
+#
+# Documentation:
+# @raycast.description Get Battery percentage, time remaining, charge status, charger wattage, total cycles etc.
+# @raycast.author Fahim Faisal
+# @raycast.authorURL https://github.com/i3p9
+
+BATT_PERCENTAGE=$(pmset -g batt | grep "InternalBattery-0" |  awk '{print $3}')
+CHARGE_STATUS=$(pmset -g batt | grep "InternalBattery-0" |  awk '{print $4}')
+TIME_REMAINING=$(pmset -g batt | grep "InternalBattery-0" |  awk '{print $5}')
+CYCLE_COUNT=$(system_profiler SPPowerDataType | grep "Cycle Count" | awk '{print $3}')
+CHARGE_WATT=$(pmset -g ac | grep "Wattage" | awk '{print $3}')
+
+BATT=${BATT_PERCENTAGE%??}
+
+if [[ "$CHARGE_STATUS" == "charging;" ]]; then
+    #Charging
+    if [[ "$TIME_REMAINING" == "(no" ]]; then
+        TO_SHOW="⚡${BATT}% - No Estimation Yet (Charging at ${CHARGE_WATT}) - ${CYCLE_COUNT} Cycles"
+        echo $TO_SHOW
+    else
+        if [[ "$TIME_REMAINING" != "(no" ]]; then
+            RE_MIN=${TIME_REMAINING##*:}
+            RE_HOUR=${TIME_REMAINING%%:*}
+            if [[ "$RE_HOUR" == "0" ]]; then
+                TIME_REMAINING_FORMATTED="${RE_MIN}m"
+            else
+                TIME_REMAINING_FORMATTED="${RE_HOUR}h ${RE_MIN}m"
+            fi
+        fi
+        TO_SHOW="⚡${BATT}% - ${TIME_REMAINING_FORMATTED} to Full (Charging at ${CHARGE_WATT}) - ${CYCLE_COUNT} Cycles"
+        echo $TO_SHOW
+    fi
+elif [[ "$CHARGE_STATUS" == "finishing" ]]; then
+    #Finishing Charning, xx:xx time remaining
+    TIME_REMAINING=$(pmset -g batt | grep "InternalBattery-0" |  awk '{print $6}')
+    RE_MIN=${TIME_REMAINING##*:}
+    RE_HOUR=${TIME_REMAINING%%:*}
+    if [[ "$RE_HOUR" == "0" ]]; then
+        if [[ "$RE_MIN" == "00" ]]; then
+            FULLY_CHARGED_FLAG="TRUE"
+        fi
+        TIME_REMAINING_FORMATTED="${RE_MIN}m"
+    else
+        TIME_REMAINING_FORMATTED="${RE_HOUR}h ${RE_MIN}m"
+    fi
+
+    if [[ "$TIME_REMAINING" == "(no" ]]; then
+        TO_SHOW="⚡${BATT}% - No Estimation Yet (Charging at ${CHARGE_WATT}) - ${CYCLE_COUNT} Cycles"
+        echo $TO_SHOW
+    elif [[ "$FULLY_CHARGED_FLAG" = "TRUE" ]]; then
+        TO_SHOW="⚡${BATT}% - Fully Charged (Power Connected at ${CHARGE_WATT}) - ${CYCLE_COUNT} Cycles"
+        echo $TO_SHOW
+    else
+        TO_SHOW="⚡${BATT}% - ${TIME_REMAINING_FORMATTED} to Full (Charging at ${CHARGE_WATT}) - ${CYCLE_COUNT} Cycles"
+        echo $TO_SHOW
+    fi
+
+elif [[ "$CHARGE_STATUS" == "charged;" ]]; then
+    #Fully charged
+    TO_SHOW="⚡${BATT}% - Fully Charged (Power Connected at ${CHARGE_WATT}) - ${CYCLE_COUNT} Cycles"
+   echo $TO_SHOW
+
+elif [[ "$CHARGE_STATUS" == "discharging;" ]]; then
+    #Discharging
+    if [[ "$TIME_REMAINING" == "(no" ]]; then
+        TO_SHOW="${BATT}% - No Estimation Yet - ${CYCLE_COUNT} Cycles"
+        echo $TO_SHOW
+    else
+        if [[ "$TIME_REMAINING" != "(no" ]]; then
+            RE_MIN=${TIME_REMAINING##*:}
+            RE_HOUR=${TIME_REMAINING%%:*}
+            if [[ "$RE_HOUR" == "0" ]]; then
+                TIME_REMAINING_FORMATTED="${RE_MIN}m"
+            else
+                TIME_REMAINING_FORMATTED="${RE_HOUR}h ${RE_MIN}m"
+            fi
+        fi
+        TO_SHOW="${BATT}% - ${TIME_REMAINING_FORMATTED} Remaining - ${CYCLE_COUNT} Cycles"
+        echo $TO_SHOW
+    fi
+fi


### PR DESCRIPTION
## Description

Script command that shows various battery info like Battery Percentage, Cycle Count, Time remaining to deplete/fuly charge, current wattage of power connected etc. 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New script command

## Screenshot

<img width="792" alt="Screen Shot 2022-03-13 at 6 08 36 PM" src="https://user-images.githubusercontent.com/8825262/158058878-912a3438-8a13-41d5-aa9a-950abdf2d038.png">

<img width="886" alt="Screen Shot 2022-03-13 at 6 07 29 PM" src="https://user-images.githubusercontent.com/8825262/158058885-e349aa9c-6291-49a1-ab98-f67051a953b7.png">

## Dependencies / Requirements
None
<!-- If it's a new script command that requires some additional steps to make it work, please describe it here. E.g. requiring installation of another command line tool or requirement to specify username / API token / etc. -->

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)