### PR TITLE
Click paste as plain text command

### DIFF
--- a/commands/conversions/paste-as-plain-text.applescript
+++ b/commands/conversions/paste-as-plain-text.applescript
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/osascript
 
 # Required parameters:
 # @raycast.schemaVersion 1
@@ -14,13 +14,8 @@
 # @raycast.author Michael Bianco
 # @raycast.authorURL https://github.com/iloveitaly
 
-osascript <<EOL
 tell application "System Events"
   tell process 1 where frontmost is true
     click menu item "Paste and Match Style" of menu "Edit" of menu bar 1
   end tell
 end tell
-EOL
-
-# ensure no toast is displayed
-echo

--- a/commands/conversions/paste-as-plain-text.sh
+++ b/commands/conversions/paste-as-plain-text.sh
@@ -2,16 +2,25 @@
 
 # Required parameters:
 # @raycast.schemaVersion 1
-# @raycast.title Paste as Plain Text
+# @raycast.title Paste and Match Style
 # @raycast.mode silent
 
 # Optional parameters:
 # @raycast.icon 📋
 # @raycast.packageName Conversions
+# @raycast.description A script to click the "Paste and Match Style" menu item, even if it's disabled
 
 # Documentation:
 # @raycast.author Michael Bianco
 # @raycast.authorURL https://github.com/iloveitaly
 
-pbpaste | pbcopy
-osascript -e 'tell application "System Events" to keystroke "v" using command down'
+osascript <<EOL
+tell application "System Events"
+  tell process 1 where frontmost is true
+    click menu item "Paste and Match Style" of menu "Edit" of menu bar 1
+  end tell
+end tell
+EOL
+
+# ensure no toast is displayed
+echo

--- a/commands/conversions/paste-as-plain-text.sh
+++ b/commands/conversions/paste-as-plain-text.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Paste as Plain Text
+# @raycast.mode silent
+
+# Optional parameters:
+# @raycast.icon 📋
+# @raycast.packageName Conversions
+
+# Documentation:
+# @raycast.author Michael Bianco
+# @raycast.authorURL https://github.com/iloveitaly
+
+pbpaste | pbcopy
+osascript -e 'tell application "System Events" to keystroke "v" using command down'


### PR DESCRIPTION
## Description

This is a follow-up to https://github.com/raycast/script-commands/pull/685

This command executes the "paste as plain text" menu item. The reason this is useful is there are some applications,
such as google sheets, which disable menu item although it can still be used. This command allows you to use this
menu item consistently regardless of if the application decides to disable the hotkeys associated with it.

## Type of change

- [x] New script command

## Screenshot

In original PR.

## Dependencies / Requirements

N/A

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)
