### PR TITLE
Adding open last downloaded script

### DIFF
--- a/commands/navigation/open-last-downloaded.sh
+++ b/commands/navigation/open-last-downloaded.sh
@@ -7,7 +7,7 @@
 # @raycast.packageName Navigation
 
 # Optional parameters:
-# @raycast.icon images/folder-home.png
+# @raycast.icon images/folder-downloads.png
 
 # Documentation:
 # @raycast.description Opens the last file that was downloaded

--- a/commands/navigation/open-last-downloaded.sh
+++ b/commands/navigation/open-last-downloaded.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Open Last Downloaded
+# @raycast.mode silent
+# @raycast.packageName Navigation
+
+# Optional parameters:
+# @raycast.icon images/folder-home.png
+
+# Documentation:
+# @raycast.description Opens the last file that was downloaded
+
+open ~/"Downloads/$(ls -tr ~/Downloads/ | tail -n 1)"


### PR DESCRIPTION
## Description

A simple script to open the last downloaded file.

Feature request: would be great if a modifier could be passed to a script so this could easily "view in finder" the last file instead of opening.

Worth noting that after I wrote this I found there was a swift script that did something similar. This shell script is ~10x faster and easier to understand, which is why I'm still submitting this PR.
## Type of change

- [x] New script command

## Screenshot

Hopefully it is simple enough this isn't needed.

## Dependencies / Requirements

N/A

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)
