### PR TITLE
OpenWeather current and forecast scripts

### DIFF
--- a/commands/dashboard/open-weather/weather-current.template.sh
+++ b/commands/dashboard/open-weather/weather-current.template.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# Dependency: This script requires `jq` cli installed: https://stedolan.github.io/jq/
+# Install via homebrew: `brew install jq`
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Current Weather
+# @raycast.mode inline
+# @raycast.refreshTime 30m
+# @raycast.packageName OpenWeather
+
+# Optional parameters:
+# @raycast.icon ⛅️
+#
+# Documentation:
+# @raycast.description Get current weather from OpenWeather
+# @raycast.author Marek Mašek
+# @raycast.authorURL https://github.com/marekmasek
+
+# you can generate API KEY here: https://home.openweathermap.org/api_keys
+API_KEY=""
+# city which will be used
+CITY="prague"
+
+if ! jq --version download &> /dev/null; then
+      echo "download jq is required (https://stedolan.github.io/jq/).";
+      exit 1;
+fi
+
+# Get location coordinates
+LOCATION_INFO=$(curl -s 'https://photon.komoot.io/api/?lang=en&limit=1&q='$CITY)
+
+LAT=$( jq -r  '.features[0].geometry.coordinates[1]' <<< "${LOCATION_INFO}" )
+LON=$( jq -r  '.features[0].geometry.coordinates[0]' <<< "${LOCATION_INFO}" )
+
+# Get weather forecast from OpenWeather
+RESPONSE=$(curl -s 'https://api.openweathermap.org/data/2.5/onecall?lat='$LAT'&lon='$LON'&units=metric&appid='$API_KEY)
+
+# This script is changing color of the output text based on the light/dark mode activated in macOS
+COLOR_MODE=$(defaults read -g AppleInterfaceStyle 2>/dev/null)
+MAIN_COLOR="\e[97m"
+
+if [ ${COLOR_MODE:-"Light"} == "Light" ]; then
+    MAIN_COLOR="\e[30m"
+fi
+
+# Build output string
+CURRENT_TEMP=$( jq -r '.current.temp*10.0|round/10.0|tostring' <<< "${RESPONSE}" )
+
+# Print output string
+printf "Temp: $MAIN_COLOR$CURRENT_TEMP °C"

--- a/commands/dashboard/open-weather/weather-forecast.template.sh
+++ b/commands/dashboard/open-weather/weather-forecast.template.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+# Dependency: This script requires `jq` cli installed: https://stedolan.github.io/jq/
+# Install via homebrew: `brew install jq`
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Weather Forecast
+# @raycast.mode inline
+# @raycast.refreshTime 30m
+# @raycast.packageName OpenWeather
+
+# Optional parameters:
+# @raycast.icon ⛅️
+#
+# Documentation:
+# @raycast.description Get weather forecast from OpenWeather
+# @raycast.author Marek Mašek
+# @raycast.authorURL https://github.com/marekmasek
+
+# you can generate API KEY here: https://home.openweathermap.org/api_keys
+API_KEY=""
+# city which will be used
+CITY="prague"
+
+if ! jq --version download &> /dev/null; then
+      echo "download jq is required (https://stedolan.github.io/jq/).";
+      exit 1;
+fi
+
+# Get location coordinates
+LOCATION_INFO=$(curl -s 'https://photon.komoot.io/api/?lang=en&limit=1&q='$CITY)
+
+LAT=$( jq -r  '.features[0].geometry.coordinates[1]' <<< "${LOCATION_INFO}" )
+LON=$( jq -r  '.features[0].geometry.coordinates[0]' <<< "${LOCATION_INFO}" )
+
+# Get weather forecast from OpenWeather
+RESPONSE=$(curl -s 'https://api.openweathermap.org/data/2.5/onecall?lat='$LAT'&lon='$LON'&units=metric&appid='$API_KEY)
+
+# This script is changing color of the output text based on the light/dark mode activated in macOS
+COLOR_MODE=$(defaults read -g AppleInterfaceStyle 2>/dev/null)
+MAIN_COLOR="\e[97m"
+RESET_COLOR="\e[0m"
+
+if [ ${COLOR_MODE:-"Light"} == "Light" ]; then
+    MAIN_COLOR="\e[30m"
+fi
+
+# Build output string
+OUTPUT_STRING=
+
+for i in {0..3}
+do
+    WORKDAY=$( date -r $( jq -r  '.daily['$i'].dt' <<< "${RESPONSE}") +%a)
+    TEMP_DAY=$( jq -r  '.daily['$i'].temp.day*10.0|round/10.0|tostring' <<< "${RESPONSE}" )
+    TEMP_NIGHT=$( jq -r  '.daily['$i'].temp.night*10.0|round/10.0|tostring' <<< "${RESPONSE}" )
+    
+    OUTPUT_STRING="$OUTPUT_STRING $WORKDAY: $MAIN_COLOR$TEMP_DAY°$RESET_COLOR / $MAIN_COLOR$TEMP_NIGHT°$RESET_COLOR"
+done
+
+# Print output string
+printf "$OUTPUT_STRING C"


### PR DESCRIPTION
## Description

<!-- Please write a short summary for this change. If it's a new script command, explain what it does. -->
Added OpenWeather template scripts for forecast and current weather. 
Forecast script is displaying day and night temperature for today and the next 3 days.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New script command

## Screenshot

<!-- If it's a new script command, please include a screenshot or a GIF of how it works. -->
current weather dark mode:
![Current-weather-dark](https://user-images.githubusercontent.com/48589322/161403779-b8bfe1b3-616f-410a-b81a-c5e72ec15388.png)
current weather light mode:
![Current-weather-light](https://user-images.githubusercontent.com/48589322/161403780-1561f5e0-c605-4f19-9195-f778a342c5a9.png)

forecast dark mode:
![forecast-dark](https://user-images.githubusercontent.com/48589322/161403788-ef7322bb-3e58-4e4c-b89a-d038179340a6.png)
forecast light mode:
![forecast-light](https://user-images.githubusercontent.com/48589322/161403791-90b1685b-5897-476a-9150-bd2bf1f49a1c.png)


## Dependencies / Requirements

<!-- If it's a new script command that requires some additional steps to make it work, please describe it here. E.g. requiring installation of another command line tool or requirement to specify username / API token / etc. -->
1. Create an OpenWeather account here: https://home.openweathermap.org/
2. Generate free API KEY here: https://home.openweathermap.org/api_keys
3. Fill in the API_KEY and CITY variables in the script

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)