### PR TITLE
Add Network Quality CLI Command

### DIFF
--- a/commands/system/network-quality.sh
+++ b/commands/system/network-quality.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Network Quality
+# @raycast.mode fullOutput
+
+# Optional parameters:
+# @raycast.icon 🌐
+
+# Documentation:
+# @raycast.author LanikSJ
+# @raycast.authorURL https://github.com/LanikSJ
+
+networkQuality -v

--- a/commands/system/network-quality.sh
+++ b/commands/system/network-quality.sh
@@ -9,8 +9,10 @@
 # @raycast.icon 🌐
 
 # Documentation:
-# @raycast.author Archie Lacoin & LanikSJ
-# @raycast.authorURL https://github.com/pomdtr & https://github.com/LanikSJ
+# @raycast.author Archie Lacoin
+# @raycast.authorURL https://github.com/pomdtr
+# @raycast.author LanikSJ
+# @raycast.authorURL https://github.com/LanikSJ
 
 result=$(networkQuality -v)
 

--- a/commands/system/network-quality.sh
+++ b/commands/system/network-quality.sh
@@ -12,4 +12,10 @@
 # @raycast.author Archie Lacoin & LanikSJ
 # @raycast.authorURL https://github.com/pomdtr & https://github.com/LanikSJ
 
-networkQuality -v
+result=$(networkQuality -v)
+
+rtt=$(echo "$result" | grep RTT | awk -F": " '{print $2}')
+mbps_down=$(echo "$result" | grep "Download capacity" | awk -F": " '{print $2}')
+mbps_up=$(echo "$result" | grep "Upload capacity" | awk -F": " '{print $2}')
+
+echo "↓ ${mbps_down}  ↑ ${mbps_up}  ↔ ${rtt} ms"

--- a/commands/system/network-quality.sh
+++ b/commands/system/network-quality.sh
@@ -9,7 +9,7 @@
 # @raycast.icon 🌐
 
 # Documentation:
-# @raycast.author LanikSJ
-# @raycast.authorURL https://github.com/LanikSJ
+# @raycast.author Archie Lacoin & LanikSJ
+# @raycast.authorURL https://github.com/pomdtr & https://github.com/LanikSJ
 
 networkQuality -v

--- a/commands/system/network-quality.sh
+++ b/commands/system/network-quality.sh
@@ -3,12 +3,14 @@
 # Required parameters:
 # @raycast.schemaVersion 1
 # @raycast.title Network Quality
-# @raycast.mode fullOutput
+# @raycast.mode inline
+# @raycast.refreshTime 20m
 
 # Optional parameters:
 # @raycast.icon 🌐
 
 # Documentation:
+# @raycast.packageName System
 # @raycast.author Archie Lacoin
 # @raycast.authorURL https://github.com/pomdtr
 # @raycast.author LanikSJ


### PR DESCRIPTION
## Description

<!-- Please write a short summary for this change. If it's a new script command, explain what it does. -->

Network Quality CLI Command for macOS aka Speedtest command.  Slack thread [here](https://raycastcommunity.slack.com/archives/C01AC2X0GMN/p1649876221157519).

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New script command

## Screenshot

<!-- If it's a new script command, please include a screenshot or a GIF of how it works. -->
![Screen Shot 2022-04-14 at 11 05 41 AM](https://user-images.githubusercontent.com/12159404/163450674-e5d55699-6b8d-42d1-a309-5cff236d2f79.png)

## Dependencies / Requirements

<!-- If it's a new script command that requires some additional steps to make it work, please describe it here. E.g. requiring installation of another command line tool or requirement to specify username / API token / etc. -->

No dependencies required the command exists within macOS.

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)