### PR TITLE
Add "Copy Focused Finder Window Path"

### DIFF
--- a/commands/developer-utils/copy-focused-finder-window-path.sh
+++ b/commands/developer-utils/copy-focused-finder-window-path.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Copy Focused Finder Window Path
+# @raycast.mode compact
+
+# Optional parameters:
+# @raycast.icon 📁
+# @raycast.packageName Developer Utils
+
+# Documentation:
+# @raycast.description Copies full path of the currently focused Finder window
+# @raycast.author Vishal Telangre
+# @raycast.authorURL https://github.com/vishaltelangre
+
+path=$(osascript <<'EOF'
+    tell application "Finder"
+        if exists Finder window 1 then
+            get the POSIX path of (target of Finder window 1 as alias)
+        else
+            get the POSIX path of (desktop as alias)
+        end if
+    end tell
+EOF
+)
+echo $path | tr -d '\n' | pbcopy
+echo "Copied $path to clipboard"

--- a/commands/developer-utils/copy-focused-finder-window-path.sh
+++ b/commands/developer-utils/copy-focused-finder-window-path.sh
@@ -3,7 +3,7 @@
 # Required parameters:
 # @raycast.schemaVersion 1
 # @raycast.title Copy Focused Finder Window Path
-# @raycast.mode compact
+# @raycast.mode silent
 
 # Optional parameters:
 # @raycast.icon 📁


### PR DESCRIPTION
## Description

Copies the absolute path of the currently focused Finder window.

## Type of change

- [x] New script command

## Screenshot

![Apr-23-2022 23-38-50](https://user-images.githubusercontent.com/876195/164934396-45a80e4e-1189-4560-b589-7dec450a3b08.gif)

## Dependencies / Requirements

Requires macOS (as Finder is available only on macOS). :)

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)