### PR TITLE
Update CoreAudio related swift scripts.

### DIFF
--- a/commands/system/audio/get-audio-devices.swift
+++ b/commands/system/audio/get-audio-devices.swift
@@ -19,6 +19,9 @@ import CoreAudio
 
 // Based on https://stackoverflow.com/a/58618034/793916
 
+// Equivalent of kAudioObjectPropertyElementMain to prevent SDK compatibility issues.
+private let audioObjectPropertyElementMain: AudioObjectPropertyElement = 0
+
 final class AudioDevice {
 
 	let audioDeviceID: AudioDeviceID
@@ -31,13 +34,13 @@ final class AudioDevice {
 		var address: AudioObjectPropertyAddress = AudioObjectPropertyAddress(
 			mSelector: AudioObjectPropertySelector(kAudioDevicePropertyStreamConfiguration),
 			mScope: AudioObjectPropertyScope(kAudioDevicePropertyScopeOutput),
-			mElement: AudioObjectPropertyElement(0))
+			mElement: audioObjectPropertyElementMain)
 
 		var propSize: UInt32 = 0
 		var result = AudioObjectGetPropertyDataSize(
 			audioDeviceID,
 			&address,
-			UInt32(MemoryLayout<AudioObjectPropertyAddress>.size),
+			0,
 			nil,
 			&propSize)
 
@@ -64,9 +67,9 @@ final class AudioDevice {
 
 	var name: String? {
 		var address = AudioObjectPropertyAddress(
-			mSelector: AudioObjectPropertySelector(kAudioDevicePropertyDeviceNameCFString),
+			mSelector: AudioObjectPropertySelector(kAudioObjectPropertyName),
 			mScope: AudioObjectPropertyScope(kAudioObjectPropertyScopeGlobal),
-			mElement: AudioObjectPropertyElement(kAudioObjectPropertyElementMaster))
+			mElement: audioObjectPropertyElementMain)
 
 		var name: CFString? = nil
 		var propSize = UInt32(MemoryLayout<CFString?>.size)
@@ -85,13 +88,13 @@ func findDevices() -> [AudioDevice] {
 	var address = AudioObjectPropertyAddress(
 		mSelector: AudioObjectPropertySelector(kAudioHardwarePropertyDevices),
 		mScope: AudioObjectPropertyScope(kAudioObjectPropertyScopeGlobal),
-		mElement: AudioObjectPropertyElement(kAudioObjectPropertyElementMaster))
+		mElement: audioObjectPropertyElementMain)
 
 	var propSize: UInt32 = 0
 	var result = AudioObjectGetPropertyDataSize(
 		AudioObjectID(kAudioObjectSystemObject),
 		&address,
-		UInt32(MemoryLayout<AudioObjectPropertyAddress>.size),
+		0,
 		nil,
 		&propSize)
 
@@ -136,7 +139,7 @@ func selectedDevice(output: Bool) -> String? {
 	var idPropertyAddress = AudioObjectPropertyAddress(
 		mSelector: AudioObjectPropertySelector(selector),
 		mScope: AudioObjectPropertyScope(kAudioObjectPropertyScopeGlobal),
-		mElement: AudioObjectPropertyElement(kAudioObjectPropertyElementMaster))
+		mElement: audioObjectPropertyElementMain)
 
 	let result = AudioObjectGetPropertyData(
 		id,

--- a/commands/system/audio/get-selected-audio-device.swift
+++ b/commands/system/audio/get-selected-audio-device.swift
@@ -20,6 +20,9 @@ import CoreAudio
 
 // Based on https://stackoverflow.com/a/58618034/793916
 
+// Equivalent of kAudioObjectPropertyElementMain to prevent SDK compatibility issues.
+private let audioObjectPropertyElementMain: AudioObjectPropertyElement = 0
+
 final class AudioDevice {
 
 	let audioDeviceID: AudioDeviceID
@@ -32,13 +35,13 @@ final class AudioDevice {
 		var address: AudioObjectPropertyAddress = AudioObjectPropertyAddress(
 			mSelector: AudioObjectPropertySelector(kAudioDevicePropertyStreamConfiguration),
 			mScope: AudioObjectPropertyScope(kAudioDevicePropertyScopeOutput),
-			mElement: AudioObjectPropertyElement(0))
+			mElement: audioObjectPropertyElementMain)
 
 		var propSize: UInt32 = 0
 		var result = AudioObjectGetPropertyDataSize(
 			audioDeviceID,
 			&address,
-			UInt32(MemoryLayout<AudioObjectPropertyAddress>.size),
+			0,
 			nil,
 			&propSize)
 
@@ -65,9 +68,9 @@ final class AudioDevice {
 
 	var name: String? {
 		var address = AudioObjectPropertyAddress(
-			mSelector: AudioObjectPropertySelector(kAudioDevicePropertyDeviceNameCFString),
+			mSelector: AudioObjectPropertySelector(kAudioObjectPropertyName),
 			mScope: AudioObjectPropertyScope(kAudioObjectPropertyScopeGlobal),
-			mElement: AudioObjectPropertyElement(kAudioObjectPropertyElementMaster))
+			mElement: audioObjectPropertyElementMain)
 
 		var name: CFString? = nil
 		var propSize = UInt32(MemoryLayout<CFString?>.size)
@@ -86,13 +89,13 @@ func findDevices() -> [AudioDevice] {
 	var address = AudioObjectPropertyAddress(
 		mSelector: AudioObjectPropertySelector(kAudioHardwarePropertyDevices),
 		mScope: AudioObjectPropertyScope(kAudioObjectPropertyScopeGlobal),
-		mElement: AudioObjectPropertyElement(kAudioObjectPropertyElementMaster))
+		mElement: audioObjectPropertyElementMain)
 
 	var propSize: UInt32 = 0
 	var result = AudioObjectGetPropertyDataSize(
 		AudioObjectID(kAudioObjectSystemObject),
 		&address,
-		UInt32(MemoryLayout<AudioObjectPropertyAddress>.size),
+		0,
 		nil,
 		&propSize)
 
@@ -137,7 +140,7 @@ func selectedDevice(output: Bool) -> String? {
 	var idPropertyAddress = AudioObjectPropertyAddress(
 		mSelector: AudioObjectPropertySelector(selector),
 		mScope: AudioObjectPropertyScope(kAudioObjectPropertyScopeGlobal),
-		mElement: AudioObjectPropertyElement(kAudioObjectPropertyElementMaster))
+		mElement: audioObjectPropertyElementMain)
 
 	let result = AudioObjectGetPropertyData(
 		id,

--- a/commands/system/audio/set-audio-device.swift
+++ b/commands/system/audio/set-audio-device.swift
@@ -34,6 +34,9 @@ import CoreAudio
 
 // Based on https://stackoverflow.com/a/58618034/793916
 
+// Equivalent of kAudioObjectPropertyElementMain to prevent SDK compatibility issues.
+private let audioObjectPropertyElementMain: AudioObjectPropertyElement = 0
+
 struct DeviceType: OptionSet {
 
 	static let input = DeviceType(rawValue: 1 << 0)
@@ -69,7 +72,7 @@ final class AudioDevice {
 		var address = AudioObjectPropertyAddress(
 			mSelector: AudioObjectPropertySelector(kAudioDevicePropertyStreamConfiguration),
 			mScope: AudioObjectPropertyScope(kAudioDevicePropertyScopeOutput),
-			mElement: AudioObjectPropertyElement(0))
+			mElement: audioObjectPropertyElementMain)
 
 		var propSize = UInt32(MemoryLayout<CFString?>.size)
 		var result = AudioObjectGetPropertyDataSize(audioDeviceID, &address, 0, nil, &propSize)
@@ -97,9 +100,9 @@ final class AudioDevice {
 
 	var name: String? {
 		var address = AudioObjectPropertyAddress(
-			mSelector: AudioObjectPropertySelector(kAudioDevicePropertyDeviceNameCFString),
+			mSelector: AudioObjectPropertySelector(kAudioObjectPropertyName),
 			mScope: AudioObjectPropertyScope(kAudioObjectPropertyScopeGlobal),
-			mElement: AudioObjectPropertyElement(kAudioObjectPropertyElementMaster))
+			mElement: audioObjectPropertyElementMain)
 
 		var name: CFString? = nil
 		var propSize = UInt32(MemoryLayout<CFString?>.size)
@@ -120,12 +123,12 @@ func findDevices() -> [AudioDevice] {
 	var address = AudioObjectPropertyAddress(
 		mSelector: AudioObjectPropertySelector(kAudioHardwarePropertyDevices),
 		mScope: AudioObjectPropertyScope(kAudioObjectPropertyScopeGlobal),
-		mElement: AudioObjectPropertyElement(kAudioObjectPropertyElementMaster))
+		mElement: audioObjectPropertyElementMain)
 
 	var result = AudioObjectGetPropertyDataSize(
 		AudioObjectID(kAudioObjectSystemObject),
 		&address,
-		UInt32(MemoryLayout<AudioObjectPropertyAddress>.size),
+		0,
 		nil,
 		&propSize)
 
@@ -179,7 +182,7 @@ func set(_ deviceType: DeviceType, to query: String) -> (Bool, String) {
 	var deviceIdPropertyAddress = AudioObjectPropertyAddress(
 		mSelector: AudioObjectPropertySelector(selector),
 		mScope: AudioObjectPropertyScope(kAudioObjectPropertyScopeGlobal),
-		mElement: AudioObjectPropertyElement(kAudioObjectPropertyElementMaster))
+		mElement: audioObjectPropertyElementMain)
 
 	let result = AudioObjectSetPropertyData(
 		AudioObjectID(kAudioObjectSystemObject),


### PR DESCRIPTION
## Description

The CoreAudio related swift scripts serves as an example of CoreAudio usage, but I found some minor issues with these scripts, and here are some quick fixes:

1. `kAudioObjectPropertyElementMaster` has been renamed to `kAudioObjectPropertyElementMain` on macOS 12 SDK. This PR makes essential adjustments so that it reportes no warnings while remaining backward compatible.
2. The third argument of `AudioObjectGetPropertyDataSize` should be 0 if the fourth argument is `nil`.
3. `kAudioDevicePropertyDeviceNameCFString` is in `CoreAudio/AudioHardwareDeprecated.h` and `kAudioObjectPropertyName` should be used instead.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] New script command
- [x] Bug fix
- [x] Improvement of an existing script
- [ ] Documentation update
- [ ] Toolkit change
- [ ] Other (Specify)

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)