### PR TITLE
Update README.md's email address

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 **✨ Looking to build richer extensions?** Check out the Extensions API [here](https://github.com/raycast/extensions).
 
-🚨 For anything that is not related to script commands, please [send us an email](feedback@raycast.com), use the feedback command within Raycast, or join the [Slack community](https://www.raycast.com/community).
+🚨 For anything that is not related to script commands, please [send us an email](mailto:feedback@raycast.com), use the feedback command within Raycast, or join the [Slack community](https://www.raycast.com/community).
 
 <br>
 <br>


### PR DESCRIPTION
## Description

Original link for feedback email was a link to `https://github.com/raycast/script-commands/feedback@raycast.com` which is not valid.
Changed to `mailto:feedback@raycast.com` which is valid.

Another option is to present the link in a code block, that is `feedback@raycast.com`, which IMO is the better option since practically nobody really likes clicking `mailto:` links and has his email setup. I reckon most people that are inclined to send an email would copy the email address.

## Type of change
- [X] Documentation update


## Checklist

- [X] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)