### PR TITLE
fix library name typo

### DIFF
--- a/commands/system/save-image-from-clipboard.py
+++ b/commands/system/save-image-from-clipboard.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 # Dependency: This script requires Pillow Python module
-# Install via Python: python3 -m pip install Pilllow
+# Install via Python: python3 -m pip install Pillow
 
 # Required parameters:
 # @raycast.schemaVersion 1


### PR DESCRIPTION
## Description

This PR fixes a typo about library name.

## Type of change
- [x] Documentation update

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)