### PR TITLE
add custom script that adds short urls with emojis 

### DIFF
--- a/commands/browsing/short-url-emoji.sh
+++ b/commands/browsing/short-url-emoji.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Shorten URL with Emojis
+# @raycast.mode compact
+# @raycast.packageName Browsing
+
+# Optional parameters:
+# @raycast.icon 🔗
+
+# Documentation:
+# @raycast.author Samuel Henry
+# @raycast.authorURL https://bne.sh
+# @raycast.description Transform the clipboard contents to a short Emoji URL
+
+regex='(https?|ftp|file)://[-A-Za-z0-9\+&@#/%?=~_|!:,.;]*[-A-Za-z0-9\+&@#/%=~_|]'
+pasteboardString=$(pbpaste)
+
+if [[ $pasteboardString =~ $regex ]]
+then
+	result=$(curl "https://bne.sh/api/shorten?url=$pasteboardString")
+    echo $result | ruby -r json -e 'puts JSON.parse(STDIN.read)["url"]' | pbcopy; echo -n `pbpaste`
+else
+	echo "String in clipboard is a not valid URL"
+	exit 1
+fi


### PR DESCRIPTION
## Description
Adds script to turn https://www.raycast.com/blog/making-a-raycast-wallpaper/ into https://bne.sh/🍗🚥🧏‍♂️

## Type of change

- [x] New script command

## Screenshot
![Kapture 2022-05-31 at 15 03 20](https://user-images.githubusercontent.com/19277887/171096714-f88f9da4-4461-4bfa-bb55-93bc35d69acc.gif)
<img width="562" alt="image" src="https://user-images.githubusercontent.com/19277887/171086620-52190181-f1c9-4711-922b-d048dc023cc1.png">
https://bne.sh/create lets you make URLs but this script lets you make a short url for free

## Dependencies / Requirements
NA

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)