### PR TITLE
feat: add toggle battery charging script

### DIFF
--- a/commands/system/toggle-battery-charging.sh
+++ b/commands/system/toggle-battery-charging.sh
@@ -6,13 +6,15 @@
 
 # Required parameters:
 # @raycast.schemaVersion 1
-# @raycast.title Toggle battery charging
+# @raycast.title Toggle Battery Charging
 # @raycast.mode silent
 
 # Optional parameters:
 # @raycast.icon 🔋
+# @raycast.packageName System
 
 # Documentation:
+# @raycast.description Toggle charging the battery when it is plugged in. When turned off, it will always use the charger instead of the battery; when turned on, it will go to automatic mode (decide based on your settings and daily charging routine).
 # @raycast.author Amir Hossein SamadiPour
 # @raycast.authorURL https://github.com/SamadiPour
 

--- a/commands/system/toggle-battery-charging.sh
+++ b/commands/system/toggle-battery-charging.sh
@@ -18,8 +18,8 @@
 # @raycast.author Amir Hossein SamadiPour
 # @raycast.authorURL https://github.com/SamadiPour
 
-status=$(battery status | awk 'NF>1{print $NF}')
-if [ "$status" = "enabled" ]; then
+hex_status=$( smc -k CH0B -r | awk '{print $4}' | sed s:\):: )
+if [[ "$hex_status" == "00" ]]; then
     battery charging off
     echo "Charging OFF"
 else

--- a/commands/system/toggle-battery-charging.sh
+++ b/commands/system/toggle-battery-charging.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Note: You must do two steps for this script to work.
+# 1- run "curl https://raw.githubusercontent.com/actuallymentor/battery/main/setup.sh | sudo bash" to install smc and battery script
+# 2- run "battery visudo" to add battery command to sudoers
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Toggle battery charging
+# @raycast.mode silent
+
+# Optional parameters:
+# @raycast.icon 🔋
+
+# Documentation:
+# @raycast.author Amir Hossein SamadiPour
+# @raycast.authorURL https://github.com/SamadiPour
+
+status=$(battery status | awk 'NF>1{print $NF}')
+if [ "$status" = "enabled" ]; then
+    battery charging off
+    echo "Charging OFF"
+else
+    battery charging on
+    echo "Charging ON"
+fi


### PR DESCRIPTION
## Description

You can toggle battery charging with this script. It depends on [smc](https://github.com/hholtmann/smcFanControl/tree/master/smc-command) to change 2 flags and enable/disable battery charging.
After changing it, it takes 30 - 70 seconds to effect and change the battery icon on menubar.

## Type of change

- [x] New script command

## Screenshot

<img width="862" alt="image" src="https://user-images.githubusercontent.com/24422125/183160063-d299920d-fc27-472a-ba26-c384f59d00d2.png">

## Dependencies / Requirements

1- run "curl https://raw.githubusercontent.com/actuallymentor/battery/main/setup.sh | sudo bash" to install smc and battery script
2- run "battery visudo" to add battery command to sudoers


## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)