### PR TITLE
feat: Add minikube commands

### DIFF
--- a/commands/developer-utils/minikube/minikube-config-set.sh
+++ b/commands/developer-utils/minikube/minikube-config-set.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Dependency: This script requires `minikube` to be installed: https://minikube.sigs.k8s.io/docs/start/
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Config Set
+# @raycast.mode compact
+# @raycast.packageName Minikube
+
+# Optional parameters:
+# @raycast.icon ⚙️
+
+# Documentation:
+# @raycast.description Pause Minikube cluster
+# @raycast.author Daniils Petrovs
+# @raycast.authorURL https://danpetrov.xyz
+# @raycast.argument1 { "type": "text", "placeholder": "property name" }
+# @raycast.argument2 { "type": "text", "placeholder": "property value" }
+
+if ! command -v minikube &> /dev/null; then
+	echo "minikube is required (https://minikube.sigs.k8s.io).";
+	exit 1;
+fi
+
+minikube config set "$1" "$2"
+
+echo "Set $1 to $2"

--- a/commands/developer-utils/minikube/minikube-pause.sh
+++ b/commands/developer-utils/minikube/minikube-pause.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Dependency: This script requires `minikube` to be installed: https://minikube.sigs.k8s.io/docs/start/
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Pause
+# @raycast.mode compact
+# @raycast.packageName Minikube
+
+# Optional parameters:
+# @raycast.icon ⏸
+
+# Documentation:
+# @raycast.description Pause Minikube cluster
+# @raycast.author Daniils Petrovs
+# @raycast.authorURL https://danpetrov.xyz
+
+if ! command -v minikube &> /dev/null; then
+	echo "minikube is required (https://minikube.sigs.k8s.io).";
+	exit 1;
+fi
+
+minikube pause
+
+echo "Cluster paused"

--- a/commands/developer-utils/minikube/minikube-start.sh
+++ b/commands/developer-utils/minikube/minikube-start.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Dependency: This script requires `minikube` to be installed: https://minikube.sigs.k8s.io/docs/start/
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Start
+# @raycast.mode compact
+# @raycast.packageName Minikube
+
+# Optional parameters:
+# @raycast.icon 🚀
+
+# Documentation:
+# @raycast.description Start Minikube cluster
+# @raycast.author Daniils Petrovs
+# @raycast.authorURL https://danpetrov.xyz
+
+if ! command -v minikube &> /dev/null; then
+	echo "minikube is required (https://minikube.sigs.k8s.io).";
+	exit 1;
+fi
+
+minikube start
+
+echo "Cluster started 🚀"

--- a/commands/developer-utils/minikube/minikube-status.sh
+++ b/commands/developer-utils/minikube/minikube-status.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Dependency: This script requires `minikube` to be installed: https://minikube.sigs.k8s.io/docs/start/
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Status
+# @raycast.mode fullOutput
+# @raycast.packageName Minikube
+
+# Optional parameters:
+# @raycast.icon ℹ️
+
+# Documentation:
+# @raycast.description Show Minikube cluster status
+# @raycast.author Daniils Petrovs
+# @raycast.authorURL https://danpetrov.xyz
+
+if ! command -v minikube &> /dev/null; then
+	echo "minikube is required (https://minikube.sigs.k8s.io).";
+	exit 1;
+fi
+
+minikube status

--- a/commands/developer-utils/minikube/minikube-stop.sh
+++ b/commands/developer-utils/minikube/minikube-stop.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Dependency: This script requires `minikube` to be installed: https://minikube.sigs.k8s.io/docs/start/
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Stop
+# @raycast.mode compact
+# @raycast.packageName Minikube
+
+# Optional parameters:
+# @raycast.icon 🤖
+
+# Documentation:
+# @raycast.description Stops a running Minikube cluster
+# @raycast.author Daniils Petrovs
+# @raycast.authorURL https://danpetrov.xyz
+
+if ! command -v minikube &> /dev/null; then
+	echo "minikube is required (https://minikube.sigs.k8s.io).";
+	exit 1;
+fi
+
+minikube stop
+
+echo "Cluster stopped"

--- a/commands/developer-utils/minikube/minikube-unpause.sh
+++ b/commands/developer-utils/minikube/minikube-unpause.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Dependency: This script requires `minikube` to be installed: https://minikube.sigs.k8s.io/docs/start/
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Unpause
+# @raycast.mode compact
+# @raycast.packageName Minikube
+
+# Optional parameters:
+# @raycast.icon ⏸
+
+# Documentation:
+# @raycast.description Pause Minikube cluster
+# @raycast.author Daniils Petrovs
+# @raycast.authorURL https://danpetrov.xyz
+
+if ! command -v minikube &> /dev/null; then
+	echo "minikube is required (https://minikube.sigs.k8s.io).";
+	exit 1;
+fi
+
+minikube unpause
+
+echo "Cluster unpaused"


### PR DESCRIPTION
## Description

This set of scripts allows users to interact with a local/remote `minikube` cluster, without leaving Raycast.

## Type of change

- [x] New script command

## Screenshot

<!-- If it's a new script command, please include a screenshot or a GIF of how it works. -->

![image](https://user-images.githubusercontent.com/5202322/183265402-b364e1d1-5d36-4dea-b7e0-8c5659cc69fb.png)

## Dependencies / Requirements

Obviously needs Minikube itself.

https://minikube.sigs.k8s.io/

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)