### PR TITLE
Add copy-ssh-public-key command

### DIFF
--- a/commands/developer-utils/copy-ssh-public-key.sh
+++ b/commands/developer-utils/copy-ssh-public-key.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Copy SSH public key
+# @raycast.mode silent
+
+# Optional parameters:
+# @raycast.icon 🔑
+# @raycast.packageName Developer Utils
+
+# Documentation:
+# @raycast.description Copying the default SSH public key to the clipboard
+# @raycast.author Angelos Michalopoulos
+# @raycast.authorURL https://github.com/miagg
+
+if [ -f "$HOME/.ssh/id_rsa.pub" ]; then
+  pbcopy < "$HOME/.ssh/id_rsa.pub"
+elif [ -f "$HOME/.ssh/id_dsa.pub" ]; then
+  pbcopy < "$HOME/.ssh/id_dsa.pub"
+elif [ -f "$HOME/.ssh/id_ed25519.pub" ]; then
+  pbcopy < "$HOME/.ssh/id_ed25519.pub"
+else
+  echo "No SSH public key was found"
+  exit 1
+fi
+
+echo "SSH public key was copied to the clipboard"
+

--- a/commands/developer-utils/copy-ssh-public-key.sh
+++ b/commands/developer-utils/copy-ssh-public-key.sh
@@ -2,7 +2,7 @@
 
 # Required parameters:
 # @raycast.schemaVersion 1
-# @raycast.title Copy SSH public key
+# @raycast.title Copy SSH Public Key
 # @raycast.mode silent
 
 # Optional parameters:


### PR DESCRIPTION
## Description

This command will copy the default public SSH key to the clipboard in order to paste it on another machine's `authorized_hosts` file or on a third-party service (AWS, DigitalOcean, etc.)

## Type of change

- [x] New script command

## Screenshot

![Raycast 2022-08-19 at 13 01 44](https://user-images.githubusercontent.com/6439071/185595658-1edc8e74-a59b-42f9-ae66-8faaa5261cb7.png)

## Dependencies / Requirements

None

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)