### PR TITLE
Add dictionary lookup command

### DIFF
--- a/commands/writing/dictionary-lookup.swift
+++ b/commands/writing/dictionary-lookup.swift
@@ -1,0 +1,42 @@
+#!/usr/bin/swift
+
+// Required parameters:
+// @raycast.schemaVersion 1
+// @raycast.title Dictionary Lookup
+// @raycast.mode compact
+
+// Optional parameters:
+// @raycast.icon 📖
+// @raycast.packageName Writing
+// @raycast.argument1 { "type": "text", "placeholder": "word or phrase" }
+
+// Documentation:
+// @raycast.description Directly use macOS Dictionary
+// @raycast.author Alessandra Pereyra
+// @raycast.authorURL https://github.com/alessandrapereyra
+
+import Cocoa
+import CoreServices.DictionaryServices
+
+func translate(_ text: String) -> String? {
+    let nsstring = text as NSString
+    let cfrange = CFRange(location: 0, length: nsstring.length)
+
+    guard let definition = DCSCopyTextDefinition(nil, nsstring, cfrange) else {
+        return nil
+    }
+
+    var foundDefinitions = String(definition.takeRetainedValue()).components(separatedBy:  "\n")
+
+    if foundDefinitions.count > 1 {
+        foundDefinitions.removeFirst()
+        foundDefinitions.removeFirst()
+        foundDefinitions.removeLast()
+    }
+
+    return foundDefinitions.joined(separator: " • ")
+}
+
+let text = CommandLine.arguments[1]
+let definition = translate(text) ?? "No definition found for \"\(text)\""
+print(definition)


### PR DESCRIPTION
## Description

Although a "Define Word" command already exists, it's currently requiring the user to select one potential entry before getting the actual definition. 

This Script Command uses macOS's DictionaryServices to query a word or phrase to the active dictionaries and return them directly, without having to switch from screens or pressing "Enter."

## Type of change

- [X] New script command

## Screenshot
![631549557b275124056213](https://user-images.githubusercontent.com/24547664/188341259-3fd73030-2db1-4288-a22b-6f4defedb905.gif)


## Checklist

- [X] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)