### PR TITLE
Adds Clipboard to Markdown script

### DIFF
--- a/commands/conversions/clipboard-to-markdown.js
+++ b/commands/conversions/clipboard-to-markdown.js
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+
+// Dependency: This script requires Nodejs.
+// Install Node: https://nodejs.org/en/download/
+
+// Required parameters:
+// @raycast.schemaVersion 1
+// @raycast.title Clipboard to Markdown
+// @raycast.mode silent
+
+// Optional parameters:
+// @raycast.icon 📋
+// @raycast.packageName Conversions
+
+// Documentation:
+// @raycast.description Automatically take the content found in the clipboard and turn it into Markdown
+// @raycast.author Alessandra Pereyra
+// @raycast.authorURL https://github.com/alessandrapereyra
+
+// Based on the code from
+// https://github.com/raycast/script-commands/blob/master/commands/conversions/create-markdown-table.js
+
+const child_process = require("child_process");
+
+function pbpaste() {
+  return child_process.execSync("pbpaste").toString();
+}
+
+function pbcopy(data) {
+  return new Promise(function (resolve, reject) {
+    const child = child_process.spawn("pbcopy");
+
+    child.on("error", function (err) {
+      reject(err);
+    });
+
+    child.on("close", function (err) {
+      resolve(data);
+    });
+
+    child.stdin.write(data);
+    child.stdin.end();
+  });
+}
+
+function processLine(content) {
+  if (
+    content.startsWith("* ") ||
+    content.startsWith("- ") ||
+    content.startsWith("+ ")
+  ) {
+    return "* " + processContent(content.substring(2));
+  }
+  return processContent(content);
+}
+
+function processLines(content) {
+  const lines = content.split("\n");
+  const markdownLines = lines.map((line) => {
+    return processLine(line);
+  });
+  return markdownLines.join("\n");
+}
+
+function processImageURL(content) {
+  return `![Image](${content})`;
+}
+
+function processURL(content) {
+  return `[${content}](${content})`;
+}
+
+function processText(content) {
+  return content;
+}
+
+function processContent(content) {
+  if (content.startsWith("http")) {
+    if (content.endsWith(".png") || content.endsWith(".jpg")) {
+      return processImageURL(content);
+    } else {
+      return processURL(content);
+    }
+  } else {
+    return processText(content);
+  }
+}
+
+function processStoredContent(content) {
+  if (content.includes("\n")) {
+    return processLines(content);
+  } else {
+    return processContent(content);
+  }
+}
+
+const storedClipboardContent = pbpaste();
+
+let markdown = processStoredContent(storedClipboardContent);
+
+pbcopy(markdown);

--- a/commands/conversions/clipboard-to-markdown.js
+++ b/commands/conversions/clipboard-to-markdown.js
@@ -76,7 +76,7 @@ function processText(content) {
 
 function processContent(content) {
   if (content.startsWith("http")) {
-    if (content.endsWith(".png") || content.endsWith(".jpg")) {
+    if (content.match(/\.(jpeg|jpg|gif|png|bmp|tiff)$/) != null) {
       return processImageURL(content);
     } else {
       return processURL(content);


### PR DESCRIPTION
## Description
This PR introduces a simple "Clipboard to Markdown" script, which allows to convert of simple content stored in the Clipboard to Markdown without any external services.

Currently, it supports regular links, images, lists, and images and links in the line items.

## Type of change

- [X] New script command

## Screenshot

<img width="448" alt="image" src="https://user-images.githubusercontent.com/24547664/188931395-3e5a9070-e590-4ce2-a2bd-61f5b29b5f4d.png">


## Dependencies / Requirements
- NodeJS

## Checklist

- [X] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)