### PR TITLE
Add Clipboard to 17TRACK script

### DIFF
--- a/commands/web-searches/clipboard-to-17track.js
+++ b/commands/web-searches/clipboard-to-17track.js
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+
+// Dependency: This script requires Nodejs.
+// Install Node: https://nodejs.org/en/download/
+
+// Required parameters:
+// @raycast.schemaVersion 1
+// @raycast.title Clipboard to 17TRACK
+// @raycast.mode silent
+// @raycast.packageName Web Searches
+
+// Optional parameters:
+// @raycast.icon 🚚
+
+// Documentation:
+// @raycast.description Open 17TRACK with the tracking code found in the clipboard
+// @raycast.author Alessandra Pereyra
+// @raycast.authorURL https://github.com/alessandrapereyra
+
+const child_process = require("child_process");
+const trackingCode = child_process.execSync("pbpaste").toString();
+
+const url = `https://t.17track.net/en#nums=${trackingCode}`;
+child_process.execSync(`open "${url}"`);


### PR DESCRIPTION
## Description

This PR introduces a "Clipboard to 17TRACK" script, which opens a 17track.net page with whichever tracking code was stored in the user's clipboard to get easy access to tracking information, provider, et al.

## Type of change

- [X] New script command

## Screenshot
![ezgif com-gif-maker (1)](https://user-images.githubusercontent.com/24547664/189400864-06eab8e4-aa2e-48ca-b978-d68d3114ff1c.gif)


## Dependencies / Requirements
- NodeJS

## Checklist

- [X] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)