### PR TITLE
Fix formatting of descriptions in VS Code related scripts

### DIFF
--- a/commands/developer-utils/vscode/open-folder-in-vscode.applescript
+++ b/commands/developer-utils/vscode/open-folder-in-vscode.applescript
@@ -10,7 +10,7 @@
 # @raycast.icon images/vscode.png
 #
 # Documentation:
-# @raycast.description Opens current topmost directory in VSCode
+# @raycast.description Opens current topmost directory in VS Code
 # @raycast.author chohner
 # @raycast.authorURL https://github.com/chohner
 

--- a/commands/developer-utils/vscode/open-project-in-vscode.sh
+++ b/commands/developer-utils/vscode/open-project-in-vscode.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Required parameters:
-# @raycast.schemaVersion 1
+# @raycast.schema Version 1
 # @raycast.title Open Project
 # @raycast.mode compact
 # @raycast.packageName VS Code
@@ -11,7 +11,7 @@
 # @raycast.argument1 { "type": "text", "placeholder": "Directory Name", "optional": false }
 
 # Documentation
-# @raycast.description Finds path to the given directory which must be a vs code or git project and opens it with VS Code
+# @raycast.description Finds path to the given directory which must be a VS Code or Git project and opens it with VS Code
 # @raycast.author Maksim Zemlyanikin
 # @raycast.authorURL https://github.com/Maksimka101
 

--- a/commands/developer-utils/vscode/open-project-in-vscode.sh
+++ b/commands/developer-utils/vscode/open-project-in-vscode.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Required parameters:
-# @raycast.schema Version 1
+# @raycast.schemaVersion 1
 # @raycast.title Open Project
 # @raycast.mode compact
 # @raycast.packageName VS Code


### PR DESCRIPTION
## Description

Hi,
I just found some formatting errors in your README which made it slightly harder for me to find scripts for VS Code. In the descriptions of the VS Code scripts, the authors have referred VS Code both as VScode and vs Code. In this commit, I've standardized it to VS Code, along with changing git to Git. Furthermore, in the name field of `extensions.json` (and therefore on `README.md`), the [name is spelled Vscode](https://github.com/safwansamsudeen/script-commands/blob/defd6466287163dae800a4a13b0b5afa145a2acf/commands/extensions.json#L9986) - could you change that too to VS Code? I would, but the Contribution Guidelines told me not to modify these files. 

Just a minor aesthetic, and thanks!

## Type of change

- [x] Documentation update

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)