### PR TITLE
fix: warp commands fail sometimes due to the order of output

### DIFF
--- a/commands/apps/warp/warp-start.sh
+++ b/commands/apps/warp/warp-start.sh
@@ -24,7 +24,7 @@ fi
 
 # Source: https://superuser.com/a/736859
 function isnt_connected () {
-    warp-cli status | sed -n 2p | grep -qv Connected
+    warp-cli status | grep Status | grep -qv Connected
 }
 
 function poll_until_connected () {

--- a/commands/apps/warp/warp-status.sh
+++ b/commands/apps/warp/warp-status.sh
@@ -23,7 +23,7 @@ if ! command -v warp-cli &> /dev/null; then
   exit 1;
 fi
 
-status=$(warp-cli status | sed -n 2p | awk 'NF>1{print $NF}')
+status=$(warp-cli status | grep Status | awk 'NF>1{print $NF}')
 
 if [ "$status" == "Connected" ] || [ "$status" == "Disconnected" ]; then
   echo "$status"

--- a/commands/apps/warp/warp-stop.sh
+++ b/commands/apps/warp/warp-stop.sh
@@ -25,7 +25,7 @@ fi
 
 # Source: https://superuser.com/a/736859
 function isnt_connected () {
-    warp-cli status | sed -n 2p | grep -qv Connected
+    warp-cli status | grep Status | grep -qv Connected
 }
 
 

--- a/commands/apps/warp/warp-toggle.sh
+++ b/commands/apps/warp/warp-toggle.sh
@@ -25,7 +25,7 @@ fi
 
 # Source: https://superuser.com/a/736859
 function isnt_connected () {
-    warp-cli status | sed -n 2p | grep -qv Connected
+    warp-cli status | grep Status | grep -qv Connected
 }
 
 function poll_until_connected () {


### PR DESCRIPTION
## Description
- The `warp-cli status` command output order is not guaranteed so the script fails sometimes.
<img width="287" alt="image" src="https://user-images.githubusercontent.com/8191266/202915371-19db065e-7548-4338-b171-dec20a25a711.png">

- Using `grep Status` to get the line with status instead of fixing to the second line.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] New script command
- [x] Bug fix
- [ ] Improvement of an existing script
- [ ] Documentation update
- [ ] Toolkit change
- [ ] Other (Specify)

## Screenshot

<!-- If it's a new script command, please include a screenshot or a GIF of how it works. -->

## Dependencies / Requirements

<!-- If it's a new script command that requires some additional steps to make it work, please describe it here. E.g. requiring installation of another command line tool or requirement to specify username / API token / etc. -->

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)