### PR TITLE
feat(browsing): command for doi string parsing

### DIFF
--- a/commands/web-searches/doi-clipboard.sh
+++ b/commands/web-searches/doi-clipboard.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Find Paper
+# @raycast.mode silent
+
+# Optional parameters:
+# @raycast.icon 📖
+# @raycast.packageName DOI
+
+# Documentation:
+# @raycast.description Scans clipboard and opens DOI links in your browser
+# @raycast.author Razvan Azamfirei
+# @raycast.authorURL https://github.com/razvanazamfirei
+LINK="$(pbpaste)"
+REGEX="^doi: 10."
+if [[ "$LINK" =~ ^doi:10. ]]; then
+    IN="$LINK"
+    arrIN=("${IN//doi:/}")
+    URL="https://doi.org/${arrIN[0]}"
+    open "$URL"
+elif [[ "$LINK" =~ ^doi/10. ]]; then
+    IN="$LINK"
+    arrIN=("${IN//doi///}")
+    URL="https://doi.org/${arrIN[0]}"
+    open "$URL"
+elif [[ "$LINK" =~ ${REGEX} ]]; then
+    IN="$LINK"
+    arrIN=("${IN//doi: //}")
+    URL="https://doi.org/${arrIN[0]}"
+    open "$URL"
+elif [[ "$LINK" =~ ^10. ]]; then
+    URL="https://doi.org/${LINK}"
+    open "$URL"
+else
+    echo "Please specify a DOI"
+    exit 1
+fi

--- a/commands/web-searches/doi.sh
+++ b/commands/web-searches/doi.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Find Paper
+# @raycast.mode silent
+
+# Optional parameters:
+# @raycast.icon 📖
+# @raycast.argument1 { "type": "text", "placeholder": "DOI" }
+# @raycast.packageName DOI
+
+# Documentation:
+# @raycast.description Parses and opens DOI links in your browser
+# @raycast.author Razvan Azamfirei
+# @raycast.authorURL https://github.com/razvanazamfirei
+LINK="$1"
+REGEX="^doi: 10."
+if [[ "$LINK" =~ ^doi:10. ]]; then
+    IN="$LINK"
+    arrIN=("${IN//doi:/}")
+    URL="https://doi.org/${arrIN[0]}"
+    open "$URL"
+elif [[ "$LINK" =~ ^doi/10. ]]; then
+    IN="$LINK"
+    arrIN=("${IN//doi///}")
+    URL="https://doi.org/${arrIN[0]}"
+    open "$URL"
+elif [[ "$LINK" =~ ${REGEX} ]]; then
+    IN="$LINK"
+    arrIN=("${IN//doi: //}")
+    URL="https://doi.org/${arrIN[0]}"
+    open "$URL"
+elif [[ "$LINK" =~ ^10. ]]; then
+    URL="https://doi.org/${LINK}"
+    open "$URL"
+else
+    echo "Please specify a DOI"
+    exit 1
+fi


### PR DESCRIPTION
## Description

This is a package that parses a doi string (unique digital object identifier used to identify academic, professional, and government information) and opens the corresponding resource. 

It supports the following formats: doi:10.* (e.g. doi:10.1136/bmj.k5094) , 10.* (e.g. 10.1136/bmj.k5094) , doi/10.* (e.g. doi/10.1136/bmj.k5094), and doi: 10.* (e.g. doi: 10.1136/bmj.k5094).

There is an additional command that scans the clipboard and identifies doi strings rather than waiting for the user to paste it into Raycast. (see second screenshot)

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] New script command
- [ ] Bug fix
- [ ] Improvement of an existing script
- [ ] Documentation update
- [ ] Toolkit change
- [ ] Other (Specify)

## Screenshot

<!-- If it's a new script command, please include a screenshot or a GIF of how it works. -->
![Screenshot](https://user-images.githubusercontent.com/7987698/208196257-ae9ee12e-7c58-47a3-8b92-43625f4cee31.png)

![CleanShot 2022-12-26 at 09 16 32](https://user-images.githubusercontent.com/7987698/209517738-bc4943f2-730c-404e-8dd9-551fedda389b.gif)


## Dependencies / Requirements

<!-- If it's a new script command that requires some additional steps to make it work, please describe it here. E.g. requiring installation of another command line tool or requirement to specify username / API token / etc. -->

No.

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)