### PR TITLE
feat: add a script to get authorization tokens from Firebase Authentication service

### DIFF
--- a/commands/dashboard/firebase/firebase-authentication-get-token.template.sh
+++ b/commands/dashboard/firebase/firebase-authentication-get-token.template.sh
@@ -53,4 +53,4 @@ curl -X POST \
   --header 'Content-Type: application/json' \
   --data-raw "$json_data" | jq -r '.idToken' | pbcopy
 
-echo 'CMS_auth_token copied to your clipboard!'
+echo 'Authorization token copied to your clipboard!'

--- a/commands/dashboard/firebase/firebase-authentication-get-token.template.sh
+++ b/commands/dashboard/firebase/firebase-authentication-get-token.template.sh
@@ -9,16 +9,15 @@
 
 # Required parameters:
 # @raycast.schemaVersion 1
-# @raycast.title Get authorization token from Firebase
+# @raycast.title Get Authorization Token
 # @raycast.mode compact
-# @raycast.refreshTime 10m
 # @raycast.packageName Firebase Authentication
 
 # Optional parameters:
 # @raycast.icon images/firebase.png
 #
 # Documentation:
-# @raycast.description Get authorization token from Firebase Authentication service
+# @raycast.description Get token from Firebase Authentication service
 # @raycast.author João Melo
 # @raycast.authorURL https://github.com/joaopcm
 
@@ -30,27 +29,27 @@ EMAIL=""
 PASSWORD=""
 
 if ! jq --version download &> /dev/null; then
-      echo "download jq is required (https://stedolan.github.io/jq/).";
-      exit 1;
+    echo "download jq is required (https://stedolan.github.io/jq/).";
+    exit 1;
 fi
 
 if [ -z "$WEB_API_KEY" ] || [ -z "$EMAIL" ] || [ -z "$PASSWORD" ]; then
-  echo "Error: You must provide WEB_API_KEY, EMAIL, and PASSWORD variables"
-  exit 1
+    echo "Error: You must provide WEB_API_KEY, EMAIL, and PASSWORD variables"
+    exit 1
 fi
 
 # Generate the request body
 json_data=$( jq -n -c \
-                      --arg email "$EMAIL" \
-                      --arg password "$PASSWORD" \
-                      --arg returnSecureToken true '$ARGS.named' )
+    --arg email "$EMAIL" \
+    --arg password "$PASSWORD" \
+    --arg returnSecureToken true '$ARGS.named' )
 
 # Get data from Firebase Authentication service and copy the token to clipboard
 curl -X POST \
-  "https://identitytoolkit.googleapis.com/v1/accounts:signInWithPassword?key=$WEB_API_KEY" \
-  --header 'Accept: */*' \
-  --header 'User-Agent: Raycast' \
-  --header 'Content-Type: application/json' \
-  --data-raw "$json_data" | jq -r '.idToken' | pbcopy
+    "https://identitytoolkit.googleapis.com/v1/accounts:signInWithPassword?key=$WEB_API_KEY" \
+    --header 'Accept: */*' \
+    --header 'User-Agent: Raycast' \
+    --header 'Content-Type: application/json' \
+    --data-raw "$json_data" | jq -r '.idToken' | pbcopy
 
 echo 'Authorization token copied to your clipboard!'

--- a/commands/dashboard/firebase/firebase-authentication-get-token.template.sh
+++ b/commands/dashboard/firebase/firebase-authentication-get-token.template.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+# Dependency: This script requires `jq` cli installed: https://stedolan.github.io/jq/
+# Install via homebrew: `brew install jq`
+
+# !!! This script is only template, you can use it to write own script to get your data from Firebase project !!!
+# If you use Firebase email and password authentication service, this script generates an authentication token
+# and copy it to your clipboard.
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Get authorization token from Firebase
+# @raycast.mode compact
+# @raycast.refreshTime 10m
+# @raycast.packageName Firebase Authentication
+
+# Optional parameters:
+# @raycast.icon images/firebase.png
+#
+# Documentation:
+# @raycast.description Get authorization token from Firebase Authentication service
+# @raycast.author João Melo
+# @raycast.authorURL https://github.com/joaopcm
+
+
+# you can find API_KEY on "Project settings -> General" page in Firebase
+WEB_API_KEY=""
+# you need to create an user with email and password on "Authentication -> Users" page in Firebase
+EMAIL=""
+PASSWORD=""
+
+if ! jq --version download &> /dev/null; then
+      echo "download jq is required (https://stedolan.github.io/jq/).";
+      exit 1;
+fi
+
+if [ -z "$WEB_API_KEY" ] || [ -z "$EMAIL" ] || [ -z "$PASSWORD" ]; then
+  echo "Error: You must provide WEB_API_KEY, EMAIL, and PASSWORD variables"
+  exit 1
+fi
+
+# Generate the request body
+json_data=$( jq -n -c \
+                      --arg email "$EMAIL" \
+                      --arg password "$PASSWORD" \
+                      --arg returnSecureToken true '$ARGS.named' )
+
+# Get data from Firebase Authentication service and copy the token to clipboard
+curl -X POST \
+  "https://identitytoolkit.googleapis.com/v1/accounts:signInWithPassword?key=$WEB_API_KEY" \
+  --header 'Accept: */*' \
+  --header 'User-Agent: Raycast' \
+  --header 'Content-Type: application/json' \
+  --data-raw "$json_data" | jq -r '.idToken' | pbcopy
+
+echo 'CMS_auth_token copied to your clipboard!'


### PR DESCRIPTION
## Description

This PR adds a script to generate authentication tokens using the Firebase Authentication service.

## Type of change

- [x] New script command

## Screenshot

![CleanShot 2022-12-27 at 19 25 41](https://user-images.githubusercontent.com/58827242/209727911-e47d2267-0281-4ebb-851d-cd8b51b75eec.gif)

## Dependencies / Requirements

<!-- If it's a new script command that requires some additional steps to make it work, please describe it here. E.g. requiring installation of another command line tool or requirement to specify username / API token / etc. -->

### `jq` cli
Install via homebrew: `brew install jq`

### Firebase API key
You can find API_KEY on the "Project settings -> General" page in Firebase.

### Email and password
You need to create a user with email and password on the "Authentication -> Users" page in Firebase.

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)