### PR TITLE
add open image from clipboard & clipboard OCR

### DIFF
--- a/commands/conversions/clipboard-ocr.sh
+++ b/commands/conversions/clipboard-ocr.sh
@@ -6,12 +6,12 @@
 
 # Required parameters:
 # @raycast.schemaVersion 1
-# @raycast.title OCR Image from Clipboard
+# @raycast.title OCR Image
 # @raycast.mode fullOutput
 
 # Optional parameters:
 # @raycast.icon 📋
-# @raycast.packageName OCR Image from Clipboard
+# @raycast.packageName Clipboard
 
 # Documentation:
 # @raycast.description OCR Image from Clipboard

--- a/commands/conversions/clipboard-ocr.sh
+++ b/commands/conversions/clipboard-ocr.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Dependency: `brew install pngpaste tesseract`
+# pngpaste required to grab image from clipboard
+# tesseract required to OCR
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title OCR Image from Clipboard
+# @raycast.mode fullOutput
+
+# Optional parameters:
+# @raycast.icon 📋
+# @raycast.packageName OCR Image from Clipboard
+
+# Documentation:
+# @raycast.description OCR Image from Clipboard
+# @raycast.author xxchan
+# @raycast.authorURL https://github.com/xxchan
+
+# credit to @laixintao https://www.kawabangga.com/posts/4876
+
+pngpaste - | tesseract stdin stdout

--- a/commands/system/open-image-from-clipboard.sh
+++ b/commands/system/open-image-from-clipboard.sh
@@ -6,12 +6,12 @@
 
 # Required parameters:
 # @raycast.schemaVersion 1
-# @raycast.title Open Image from Clipboard
+# @raycast.title Open Image
 # @raycast.mode compact
 
 # Optional parameters:
 # @raycast.icon 📋
-# @raycast.packageName Open Image from Clipboard
+# @raycast.packageName Clipboard
 
 # Documentation:
 # @raycast.description Open Image from Clipboard in Preview for OCR or other purposes.

--- a/commands/system/open-image-from-clipboard.sh
+++ b/commands/system/open-image-from-clipboard.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Dependency: `brew install pngpaste coreutils`
+# pngpaste required to grab image from clipboard
+# coreutils required to create temp file with suffix
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Open Image from Clipboard
+# @raycast.mode compact
+
+# Optional parameters:
+# @raycast.icon 📋
+# @raycast.packageName Open Image from Clipboard
+
+# Documentation:
+# @raycast.description Open Image from Clipboard in Preview for OCR or other purposes.
+# @raycast.author xxchan
+# @raycast.authorURL https://github.com/xxchan
+
+tempfile=$(gmktemp --suffix=.png) && pngpaste $tempfile && open $tempfile


### PR DESCRIPTION

## Description

<!-- Please write a short summary for this change. If it's a new script command, explain what it does. -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New script command
- [ ] Bug fix
- [ ] Improvement of an existing script
- [ ] Documentation update
- [ ] Toolkit change
- [ ] Other (Specify)

## Screenshot

<!-- If it's a new script command, please include a screenshot or a GIF of how it works. -->

<img width="1228" alt="image" src="https://user-images.githubusercontent.com/37948597/215344930-0d68e738-b581-4132-9292-d0604abc1f2a.png">


## Dependencies / Requirements

<!-- If it's a new script command that requires some additional steps to make it work, please describe it here. E.g. requiring installation of another command line tool or requirement to specify username / API token / etc. -->
Dependency: `brew install pngpaste coreutils`
pngpaste required to grab image from clipboard
coreutils required to create temp file with suffix

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)