### PR TITLE
Fix command to remove iOS Device Logs folder

### DIFF
--- a/commands/developer-utils/clear_xcode.sh
+++ b/commands/developer-utils/clear_xcode.sh
@@ -21,6 +21,6 @@ xcrun simctl delete unavailable
 
 rm -rf ~/Library/Developer/Xcode/Archives
 rm -rf ~/Library/Developer/Xcode/DerivedData
-rm -rf ~/Library/Developer/Xcode/iOS Device Logs
+rm -rf ~/Library/Developer/Xcode/iOS\ Device\ Logs/
 
 echo "Junk removed!"


### PR DESCRIPTION
## Description

Update the command adding escaping character for the spaces on `iOS Device Logs` folder generated by Xcode

## Type of change

- [x] Improvement of an existing script

## Screenshot

N/A

## Dependencies / Requirements

N/A

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)