### PR TITLE
Fix file encoding

### DIFF
--- a/commands/apps/safari/safari-bing-edge-user-agent.applescript
+++ b/commands/apps/safari/safari-bing-edge-user-agent.applescript
@@ -17,7 +17,7 @@ tell application "Safari"
 	set theURL to "https://www.bing.com"
 	set newTab to make new tab at end of tabs of window 1
 	set current tab of window 1 to newTab
-	set theUserAgent to "Microsoft Edge ¡ª MacOS"
+	set theUserAgent to "Microsoft Edge Â¡Âª MacOS"
 	set URL of newTab to theURL
 	tell application "System Events"
 		tell process "Safari"


### PR DESCRIPTION
## Description
I'd like to try #820, but when I added the `safari` folder as my script directory, I can't find it in the script commands.

![image](https://user-images.githubusercontent.com/11025519/219607324-54de3601-b003-4662-b3f5-811d2c7ed476.png)

After discovering that the issue was caused by the file encoding, I changed it to UTF-8, which resolved the problem.

![image](https://user-images.githubusercontent.com/11025519/219608022-7cd8d873-a48b-47e0-a2a6-fb6a88a56a84.png)


## Type of change
- [x] Other (Specify)

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)