### PR TITLE
Updated functionality of is-it-up.sh

### DIFF
--- a/commands/developer-utils/is-it-up.sh
+++ b/commands/developer-utils/is-it-up.sh
@@ -23,7 +23,19 @@ if ! command -v jq &> /dev/null; then
   exit 1;
 fi
 
-status_code=$(curl --silent "https://isitup.org/$1.json" | jq '.status_code')
+# Get the url from the user input
+url=$1
+
+# Remove any protocol prefix (http:// or https://)
+url=${url#*://}
+
+# Remove any www. prefix
+url=${url#www.}
+
+# Remove any trailing slash
+url=${url%/}
+
+status_code=$(curl --silent "https://isitup.org/${url}.json" | jq '.status_code')
 
 # Sample output:
 #


### PR DESCRIPTION
Updated script to work with urls with http://, https://, and www. without giving an error.

## Description

Updated command to fix a common bug. 

## Type of change

Bug fix / expansion of functionality.

- [  ] New script command
- [ x ] Bug fix
- [ x ] Improvement of an existing script
- [  ] Documentation update
- [  ] Toolkit change
- [  ] Other (Specify)

## Checklist

- [ x ] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)