### PR TITLE
feat(zoom): add zoom rename profile script

### DIFF
--- a/commands/communication/zoom/rename-profile.applescript
+++ b/commands/communication/zoom/rename-profile.applescript
@@ -1,0 +1,70 @@
+#!/usr/bin/osascript
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Rename Profile
+# @raycast.description Rename your profile in Zoom Meeting App (Mac Only) and cliclick.
+# @raycast.mode silent
+# @raycast.packageName Zoom
+# @raycast.argument1 { "type": "text", "placeholder": "AFK for?" }
+
+# Optional parameters:
+# @raycast.icon images/zoom-logo.png
+
+# Documentation:
+# @raycast.author Leo Voon
+# @raycast.authorURL https://github.com/leovoon
+
+on run argv
+	
+	tell application "System Events"
+		tell application process "zoom.us"
+			set frontmost to true
+			set windowIsOpen to false
+			set participantsWindow to missing value
+			set renameWindow to missing value
+			
+			repeat with w in windows
+				if name of w contains "Participants" then
+					set windowIsOpen to true
+					set participantsWindow to w
+					exit repeat
+				end if
+			end repeat
+			
+			delay 0.5
+			set foundRename to false
+			-- Hover on name
+			do shell script "/opt/homebrew/bin/cliclick m:" & 1183 & "," & 124
+			delay 0.5
+
+			-- Hover on More button
+			do shell script "/opt/homebrew/bin/cliclick m:" & 1400 & "," & 124
+			delay 0.5
+
+			-- Click More button
+			do shell script "/opt/homebrew/bin/cliclick c:" & 1400 & "," & 124
+			delay 0.5	
+
+			-- Click Arrow Down
+			do shell script "/opt/homebrew/bin/cliclick kp:arrow-down kp:arrow-down kp:return"
+			delay 0.5
+
+			-- Target Rename and Hit Return Key
+			do shell script "/opt/homebrew/bin/cliclick kp:return"
+			
+			-- Edit Input, modify here for your needs
+			delay 0.5
+			set newName to "YOUR NAME -" & ( item 1 of argv )
+			delay 0.5
+			do shell script "/opt/homebrew/bin/cliclick c:" & 888 & "," & 430
+			delay 0.5
+			key code 51 using {command down}
+			keystroke newName
+			delay 0.5
+			do shell script "/opt/homebrew/bin/cliclick c:" & 880 & "," & 517
+			
+			
+		end tell
+	end tell
+end run


### PR DESCRIPTION
## Description

<!-- Please write a short summary for this change. If it's a new script command, explain what it does. -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New script command
- [ ] Bug fix
- [ ] Improvement of an existing script
- [ ] Documentation update
- [ ] Toolkit change
- [ ] Other (Specify)

## Screenshot
[![zoom-rename.gif](https://i.postimg.cc/JhBSPpBK/zoom-rename.gif)](https://postimg.cc/TyfkPq0W)
<!-- If it's a new script command, please include a screenshot or a GIF of how it works. -->

## Dependencies / Requirements

To use this script, you will need cliclick installed on your machine. You can install it via Homebrew using the command `brew install cliclick`.

Once installed, open a terminal and run the command `which cliclick` to get its path. For example, the output might be `/opt/homebrew/bin/cliclick`. Replace the path in the script with the one you obtained. This script may become outdated if Zoom App updates its layout in the future. Manual fine tuning the x,y of mouse coordinates may necessary.


<!-- If it's a new script command that requires some additional steps to make it work, please describe it here. E.g. requiring installation of another command line tool or requirement to specify username / API token / etc. -->

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)