### PR TITLE
Add sourcegraph search command

### DIFF
--- a/commands/web-searches/search-sourcegraph.sh
+++ b/commands/web-searches/search-sourcegraph.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Search in sourcegraph.com
+# @raycast.mode silent
+# @raycast.packageName Web Searches
+
+# Optional parameters:
+# @raycast.icon https://sourcegraph.com/.assets/img/sourcegraph-mark.svg?v2
+# @raycast.argument1 { "type": "text", "placeholder": "query", "percentEncoded": true }
+
+open "https://sourcegraph.com/?q=context%3Aglobal+${1}"


### PR DESCRIPTION
## Description

<!-- Please write a short summary for this change. If it's a new script command, explain what it does. -->

Allows you to search sourcegraph.com, as an alternative to [grep-app-search.sh](https://github.com/raycast/script-commands/blob/master/commands/web-searches/grep-app-search.sh).

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New script command

## Screenshot

<!-- If it's a new script command, please include a screenshot or a GIF of how it works. -->

![image](https://github.com/raycast/script-commands/assets/24568457/50d19e03-1e76-4374-9cc5-86f5c80628c5)

## Dependencies / Requirements

<!-- If it's a new script command that requires some additional steps to make it work, please describe it here. E.g. requiring installation of another command line tool or requirement to specify username / API token / etc. -->

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)