### PR TITLE
Update imgur-upload-clipboard-image.template.sh to fix url parsing.

### DIFF
--- a/commands/productivity/imgur/imgur-upload-clipboard-image.template.sh
+++ b/commands/productivity/imgur/imgur-upload-clipboard-image.template.sh
@@ -80,7 +80,7 @@ else
     delete_hash="${output##*<deletehash>}"
     delete_hash="${delete_hash%%</deletehash>*}"
 
-    echo -n "$url" | pbcopy
+    echo -n "$url" | sed 's/\\\//\//g' | pbcopy
     jobdone=0
 fi
 


### PR DESCRIPTION
## Description

After testing, the url returned by the current imgur api contains an escape for "/". 

The response is like: `"link":"https:\/\/i.imgur.com\/0UTnNoS.png"`.

So I added a simple sed command to correct the parsing of links.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix
- [x] Improvement of an existing script

## Screenshot

<!-- If it's a new script command, please include a screenshot or a GIF of how it works. -->

## Dependencies / Requirements

<!-- If it's a new script command that requires some additional steps to make it work, please describe it here. E.g. requiring installation of another command line tool or requirement to specify username / API token / etc. -->

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)