### PR TITLE
✨ add command to convert twitter link to nitter

### DIFF
--- a/commands/browsing/convert-twitter-to-nitter.js
+++ b/commands/browsing/convert-twitter-to-nitter.js
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+// Dependency: This script requires Nodejs.
+// Install Node: https://nodejs.org/en/download/
 
 // Required parameters:
 // @raycast.schemaVersion 1

--- a/commands/browsing/convert-twitter-to-nitter.js
+++ b/commands/browsing/convert-twitter-to-nitter.js
@@ -14,11 +14,10 @@
 // @raycast.description Convert Twitter link to Nitter
 // @raycast.author cSharp
 // @raycast.authorURL https://github.com/noidwasavailable
-// @raycast.argument1 { "type": "text", "placeholder": "Twitter Link" }
 
 // Example Twitter link: https://twitter.com/Cron/status/1644010827647975425
 const child_process = require('child_process');
-let [link] = process.argv.slice(2);
+let link = child_process.execSync("pbpaste").toString();
 
 if (!link) {
   console.error('No link provided');

--- a/commands/browsing/convert-twitter-to-nitter.js
+++ b/commands/browsing/convert-twitter-to-nitter.js
@@ -12,8 +12,8 @@
 
 // Documentation:
 // @raycast.description Convert Twitter link to Nitter
-// @raycast.author csharp
-// @raycast.authorURL https://raycast.com/csharp
+// @raycast.author cSharp
+// @raycast.authorURL https://github.com/noidwasavailable
 // @raycast.argument1 { "type": "text", "placeholder": "Twitter Link" }
 
 // Example Twitter link: https://twitter.com/Cron/status/1644010827647975425

--- a/commands/browsing/convert-twitter-to-nitter.js
+++ b/commands/browsing/convert-twitter-to-nitter.js
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+
+// Required parameters:
+// @raycast.schemaVersion 1
+// @raycast.title Convert Twitter to Nitter
+// @raycast.mode silent
+
+// Optional parameters:
+// @raycast.icon 🐔
+
+// Documentation:
+// @raycast.description Convert Twitter link to Nitter
+// @raycast.author csharp
+// @raycast.authorURL https://raycast.com/csharp
+// @raycast.argument1 { "type": "text", "placeholder": "Twitter Link" }
+
+// Example Twitter link: https://twitter.com/Cron/status/1644010827647975425
+const child_process = require('child_process');
+let [link] = process.argv.slice(2);
+
+if (!link) {
+  console.error('No link provided');
+  return;
+}
+
+try {
+  link = link.replace('twitter.com', 'nitter.net');
+  console.log(`Opening ${link}`);
+  child_process.execSync(`open "${link}"`);
+  return;
+} catch (error) {
+  console.error('Invalid link provided');
+  return;
+}


### PR DESCRIPTION
## Description

<!-- Please write a short summary for this change. If it's a new script command, explain what it does. -->

A new script command that takes in a twitter link as an argument and converts it to a nitter.net link and open it in the default browser.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New script command

## Screenshot

<!-- If it's a new script command, please include a screenshot or a GIF of how it works. -->
[Passing a Twitter link as an argument](https://imgur.com/u5L8Vau)
[Opening a new browser window with a prompt](https://imgur.com/Vo63WZG)
[Opened link](https://imgur.com/LNuQZiE)

## Dependencies / Requirements

<!-- If it's a new script command that requires some additional steps to make it work, please describe it here. E.g. requiring installation of another command line tool or requirement to specify username / API token / etc. -->

None

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)