### PR TITLE
Add Warp reauth command

### DIFF
--- a/commands/apps/warp/warp-reauth.sh
+++ b/commands/apps/warp/warp-reauth.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Dependency: Cloudflare WARP https://developers.cloudflare.com/warp-client/setting-up/macOS
+# Note: Cloudflare WARP must be installed, but CLI works properly only if GUI-client is not running
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Reauthenticate
+# @raycast.mode compact
+
+# Optional parameters:
+# @raycast.icon images/warp.png
+
+# @Documentation:
+# @raycast.packageName WARP
+# @raycast.description Force WARP reauthentication
+# @raycast.author Daniils Petrovs
+# @raycast.authorURL https://github.com/danirukun
+
+
+if ! command -v warp-cli &> /dev/null; then
+  echo "WARP is required (https://developers.cloudflare.com/warp-client/setting-up/macOS)";
+  exit 1;
+fi
+
+warp-cli access-reauth
+echo "Opening WARP authentication page"


### PR DESCRIPTION
## Description

Adds a missing command to the WARP package - reauthenticate.
In our usecase, just toggling Warp is not enough - we have day-long sessions so we need to trigger a reauth manually a lot.

## Type of change

- [x] New script command

## Screenshot

<img width="862" alt="image" src="https://github.com/raycast/script-commands/assets/5202322/1f07381d-87cb-4cd7-bcac-83dd68ab39e1">


## Dependencies / Requirements

WARP CLI (nothing new WARP related).

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)