### PR TITLE
Add command to join clipboard lines by delimiter

### DIFF
--- a/commands/developer-utils/join-lines.sh
+++ b/commands/developer-utils/join-lines.sh
@@ -13,6 +13,7 @@
 # Documentation:
 # @raycast.description Join multiple lines of text from the clipboard into a single line, separated by a specified delimiter.
 # @raycast.author decaylala
+# @raycast.authorURL https://github.com/decaylala
 
 pbpaste | awk -v d="$1" 'BEGIN {ORS=d} {print}' | awk -v d="$1" 'sub(d "$", "")' | pbcopy
 echo 'Copied to clipboard'

--- a/commands/developer-utils/join-lines.sh
+++ b/commands/developer-utils/join-lines.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Join Clipboard Lines by Delimiter
+# @raycast.mode silent
+
+# Optional parameters:
+# @raycast.icon 🛠
+# @raycast.argument1 { "type": "text", "placeholder": "delimiter", "optional": true }
+# @raycast.packageName Developer Utilities
+
+# Documentation:
+# @raycast.description Join multiple lines of text from the clipboard into a single line, separated by a specified delimiter.
+# @raycast.author decaylala
+
+pbpaste | awk -v d="$1" 'BEGIN {ORS=d} {print}' | awk -v d="$1" 'sub(d "$", "")' | pbcopy
+echo 'Copied to clipboard'


### PR DESCRIPTION
## Description

<!-- Please write a short summary for this change. If it's a new script command, explain what it does. -->
Adds a new script command that joins multiple lines of text from the clipboard into a single line, separated by a specified delimiter.

Suppose the clipboard content is as follows and the delimiter specified is `-`:

```
apple
banana
cherry
```

This will result in the new clipboard content being:

```
apple-banana-cherry
```

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New script command

## Screenshot

<!-- If it's a new script command, please include a screenshot or a GIF of how it works. -->
<img width="781" alt="CleanShot 2023-08-27 at 19 28 34@2x" src="https://github.com/raycast/script-commands/assets/442899/beca22b9-194c-44a6-955c-1976a8c7133f">


## Dependencies / Requirements

<!-- If it's a new script command that requires some additional steps to make it work, please describe it here. E.g. requiring installation of another command line tool or requirement to specify username / API token / etc. -->

None

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)