### PR TITLE
added new command to toggle sleep when laptop lid's closed

### DIFF
--- a/commands/system/clamshell.sh
+++ b/commands/system/clamshell.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Note: You must add pmset to sudoers for this script to work.
+# 1- run to create file and open editor:
+# sudo visudo -f /etc/sudoers.d/pmset
+# 2- press 'i' to enter input mode
+# 3- paste this line into the editor:
+# ALL ALL=NOPASSWD: /usr/bin/pmset
+# 4- press 'esc' to exit input mode
+# 5- type this to exit and save file:
+# :wq
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Clamshell
+# @raycast.mode inline
+
+# Optional parameters:
+# @raycast.icon 🐚
+# @raycast.packageName Personal
+
+# Documentation:
+# @raycast.description Toggle sleep when laptop lid's closed
+# @raycast.author Ivan Rybalko
+# @raycast.authorURL https://github.com/ivribalko
+
+sudo -l | grep -wq /usr/bin/pmset
+
+if [[ $? -eq 1 ]]; then
+    echo "pmset is not in sudoers, see command's code for instructions."
+    exit 1
+fi
+
+if [[ $(pmset -g | grep SleepDisabled | cut -f3) -eq '1' ]]; then
+    sudo pmset disablesleep 0
+    echo off 💤
+else
+    sudo pmset disablesleep 1
+    echo on ☕
+fi


### PR DESCRIPTION
## Description

Added a new script command that toggles macOS setting that prevents laptop from going to sleep when lid's closed:

<img width="766" alt="image" src="https://github.com/raycast/script-commands/assets/20713003/301fc5fd-3cec-40d8-966e-fa26b4322ab9">

<img width="766" alt="image" src="https://github.com/raycast/script-commands/assets/20713003/16c61c93-13ed-40e7-bb31-7554575db0b7">


## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] New script command
- [ ] Bug fix
- [ ] Improvement of an existing script
- [ ] Documentation update
- [ ] Toolkit change
- [ ] Other (Specify)

## Screenshot

<!-- If it's a new script command, please include a screenshot or a GIF of how it works. -->

## Dependencies / Requirements

<!-- If it's a new script command that requires some additional steps to make it work, please describe it here. E.g. requiring installation of another command line tool or requirement to specify username / API token / etc. -->

## Checklist

- [ ] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)