### PR TITLE
added command to toggle sleep when laptop lid's closed

### DIFF
--- a/commands/system/toggle-lid-sleep.sh
+++ b/commands/system/toggle-lid-sleep.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Note: You must add pmset to sudoers for this script to work.
+# 1- run to create file and open editor:
+# sudo visudo -f /etc/sudoers.d/pmset
+# 2- press 'i' to enter input mode
+# 3- paste this line into the editor:
+# ALL ALL=NOPASSWD: /usr/bin/pmset
+# 4- press 'esc' to exit input mode
+# 5- type this to exit and save file:
+# :wq
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Toggle Lid Sleep
+# @raycast.mode inline
+
+# Optional parameters:
+# @raycast.icon 🐚
+# @raycast.packageName Personal
+
+# Documentation:
+# @raycast.description Prevent sleep when laptop lid's closed (clamshell mode)
+# @raycast.author Ivan Rybalko
+# @raycast.authorURL https://github.com/ivribalko
+
+validate_exit_code()
+{
+    if [[ $? -eq 1 ]]; then
+        echo "pmset is not in sudoers, see sources for how-to."
+        exit 1
+    fi
+}
+
+if [[ $(pmset -g | grep SleepDisabled | cut -f3) -eq '1' ]]; then
+    sudo pmset disablesleep 0 2> /dev/null
+    validate_exit_code
+    echo on 💤
+else
+    sudo pmset disablesleep 1 2> /dev/null
+    validate_exit_code
+    echo off ☕
+fi


### PR DESCRIPTION
## Description

Added a new script command that toggles macOS setting that prevents laptop from going to sleep when lid's closed:

<img width="764" alt="image" src="https://github.com/raycast/script-commands/assets/20713003/69318e23-7a64-41e1-949c-9b5917b45d08">

<img width="762" alt="image" src="https://github.com/raycast/script-commands/assets/20713003/5f1fc3bd-7919-46a7-973d-d73061290d52">

<img width="764" alt="image" src="https://github.com/raycast/script-commands/assets/20713003/126165b9-b9e7-497e-9d28-eccdfd20b0a6">

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New script command
- [ ] Bug fix
- [ ] Improvement of an existing script
- [ ] Documentation update
- [ ] Toolkit change
- [ ] Other (Specify)

## Screenshot

<!-- If it's a new script command, please include a screenshot or a GIF of how it works. -->

## Dependencies / Requirements

<!-- If it's a new script command that requires some additional steps to make it work, please describe it here. E.g. requiring installation of another command line tool or requirement to specify username / API token / etc. -->

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)