### PR TITLE
feat: Add View Scripting Dictionary command

### DIFF
--- a/commands/developer-utils/view-scripting-dictionary.sh
+++ b/commands/developer-utils/view-scripting-dictionary.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title View Scripting Dictionary
+# @raycast.mode silent
+
+# Optional parameters:
+# @raycast.icon 📖
+# @raycast.argument1 { "type": "text", "placeholder": "Application", "optional": true }
+# @raycast.packageName Developer Utils
+
+# Documentation:
+# @raycast.description Opens the Scripting Dictionary for the given application, defaulting to the active application if none is provided.
+# @raycast.author Stephen Kaplan
+# @raycast.authorURL https://github.com/SKaplanOfficial
+
+if [ -z "$1" ]; then
+  open -a "Script Editor" "$(osascript -e "tell application \"System Events\" to get POSIX path of application file of (first application process whose frontmost is true)")"
+  exit
+fi
+open -a "Script Editor" "$(osascript -e "POSIX path of (path to application \"$1\")")"
+


### PR DESCRIPTION
## Description

Added a new script command that opens the Scripting Dictionary for the frontmost application or the application specified via the argument. If an application doesn't have a scripting dictionary, the error is handled by Script Editor.

## Type of change

- [x] New script command

## Screenshot

![ViewScriptingDictionary](https://github.com/raycast/script-commands/assets/7865925/1afc5925-1afa-4e08-b99c-6a0c5abb8cf0)

## Dependencies / Requirements

None beyond base macOS.

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)