### PR TITLE
Create reset-launchpad.sh

### DIFF
--- a/commands/system/reset-launchpad.sh
+++ b/commands/system/reset-launchpad.sh
@@ -11,7 +11,7 @@
 
 # Documentation:
 # @raycast.description Resets the macOS Launchpad to its default state
-# @raycast.author zdawz
+# @raycast.author Zach Dawson
 # @raycast.authorURL https://raycast.com/zdawz
 
 defaults write com.apple.dock ResetLaunchPad -bool true

--- a/commands/system/reset-launchpad.sh
+++ b/commands/system/reset-launchpad.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Reset Launchpad
+# @raycast.mode silent
+
+# Optional parameters:
+# @raycast.icon 🚀
+# @raycast.packageName System
+
+# Documentation:
+# @raycast.description Resets the macOS Launchpad to its default state
+# @raycast.author zdawz
+# @raycast.authorURL https://raycast.com/zdawz
+
+defaults write com.apple.dock ResetLaunchPad -bool true
+killall Dock


### PR DESCRIPTION
## Description

Create a new script command that resets the macOS Launchpad to its default state. Useful for when you've made a lot of changes to Launchpad and just want to start fresh.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New script command
- [ ] Bug fix
- [ ] Improvement of an existing script
- [ ] Documentation update
- [ ] Toolkit change
- [ ] Other (Specify)

## Screenshot

Could not make GIF small enough. Can provide screenshots upon request.

## Dependencies / Requirements

N/A

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)