### PR TITLE
Adds current browser check for compatibility with Chrome confirmation…

### DIFF
--- a/commands/system/default-browser-arc.applescript
+++ b/commands/system/default-browser-arc.applescript
@@ -17,6 +17,9 @@
 # @raycast.authorURL https://github.com/dehesa
 # @raycast.description Set Arc as the default browser.
 
+# check to see what the current browser is
+set currentDefaultBrowser to my getCurrentDefaultBrowser()
+
 set repeatCount to 0
 
 tell application "System Events"
@@ -28,7 +31,12 @@ tell application "System Events"
 			if repeatCount = 15 then exit repeat
 		end repeat
 		try
-			click button 2 of window 1 of process "CoreServicesUIAgent"
+			# if Chrome is the current default browser, the order of the buttons is reversed. Click button 1 to change the default browser to Arc.
+			if currentDefaultBrowser contains "com.google.chrome" then
+                click button 1 of window 1 of process "CoreServicesUIAgent"
+            else    # otherwise click button 2 to change the default browser to Arc.
+                click button 2 of window 1 of process "CoreServicesUIAgent"
+            end if
 			log "Arc is now your default browser"
 		on error
 			log "Arc is already your default browser"
@@ -37,6 +45,13 @@ tell application "System Events"
 		log "The \"defaultbrowser\" CLI tool is required: https://github.com/kerma/defaultbrowser 🔥"
 	end try
 end tell
+
+to getCurrentDefaultBrowser()
+    set filePath to "~/Library/Preferences/com.apple.LaunchServices/com.apple.launchservices.secure.plist"
+
+    set output to do shell script "plutil -p " & filePath & " | awk '/LSHandlerRoleAll/{a=$3}/LSHandlerURLScheme/{if($3==\"\\\"https\\\"\") print a}'"
+    return output
+end getCurrentDefaultBrowser
 
 to changeDefaultBrowser(thebrowser)
 	do shell script "

--- a/commands/system/default-browser-firefox.applescript
+++ b/commands/system/default-browser-firefox.applescript
@@ -17,6 +17,9 @@
 # @raycast.authorURL https://github.com/dehesa
 # @raycast.description Set Firefox as the default browser.
 
+# check to see what the current browser is
+set currentDefaultBrowser to my getCurrentDefaultBrowser()
+
 set repeatCount to 0
 
 tell application "System Events"
@@ -28,7 +31,12 @@ tell application "System Events"
 			if repeatCount = 15 then exit repeat
 		end repeat
 		try
-			click button 2 of window 1 of process "CoreServicesUIAgent"
+			# if Chrome is the current default browser, the order of the buttons is reversed. Click button 1 to change the default browser to FF.
+			if currentDefaultBrowser contains "com.google.chrome" then
+                click button 1 of window 1 of process "CoreServicesUIAgent"
+            else    # otherwise click button 2 to change the default browser to FF.
+                click button 2 of window 1 of process "CoreServicesUIAgent"
+            end if
 			log "Firefox is now your default browser"
 		on error
 			log "Firefox is already your default browser"
@@ -37,6 +45,13 @@ tell application "System Events"
 		log "The \"defaultbrowser\" CLI tool is required: https://github.com/kerma/defaultbrowser 🔥"
 	end try
 end tell
+
+to getCurrentDefaultBrowser()
+    set filePath to "~/Library/Preferences/com.apple.LaunchServices/com.apple.launchservices.secure.plist"
+
+    set output to do shell script "plutil -p " & filePath & " | awk '/LSHandlerRoleAll/{a=$3}/LSHandlerURLScheme/{if($3==\"\\\"https\\\"\") print a}'"
+    return output
+end getCurrentDefaultBrowser
 
 to changeDefaultBrowser(thebrowser)
 	do shell script "

--- a/commands/system/default-browser-safari.applescript
+++ b/commands/system/default-browser-safari.applescript
@@ -17,6 +17,9 @@
 # @raycast.authorURL https://github.com/dehesa
 # @raycast.description Set Safari as the default browser.
 
+# check to see what the current browser is
+set currentDefaultBrowser to my getCurrentDefaultBrowser()
+
 set repeatCount to 0
 
 tell application "System Events"
@@ -28,7 +31,12 @@ tell application "System Events"
 			if repeatCount = 15 then exit repeat
 		end repeat
 		try
-			click button 2 of window 1 of process "CoreServicesUIAgent"
+			# if Chrome is the current default browser, the order of the buttons is reversed. Click button 1 to change the default browser to Safari.
+			if currentDefaultBrowser contains "com.google.chrome" then
+                click button 1 of window 1 of process "CoreServicesUIAgent"
+            else    # otherwise click button 2 to change the default browser to Safari.
+                click button 2 of window 1 of process "CoreServicesUIAgent"
+            end if
 			log "Safari is now your default browser"
 		on error
 			log "Safari is already your default browser"
@@ -37,6 +45,13 @@ tell application "System Events"
 		log "The \"defaultbrowser\" CLI tool is required: https://github.com/kerma/defaultbrowser 🔥"
 	end try
 end tell
+
+to getCurrentDefaultBrowser()
+    set filePath to "~/Library/Preferences/com.apple.LaunchServices/com.apple.launchservices.secure.plist"
+
+    set output to do shell script "plutil -p " & filePath & " | awk '/LSHandlerRoleAll/{a=$3}/LSHandlerURLScheme/{if($3==\"\\\"https\\\"\") print a}'"
+    return output
+end getCurrentDefaultBrowser
 
 to changeDefaultBrowser(thebrowser)
 	do shell script "


### PR DESCRIPTION
… dialog when switching from Chrome to another browser

## Description

<!-- Please write a short summary for this change. If it's a new script command, explain what it does. -->

I modified the following three files in commands/system:

default-browser-arc.applescript
default-browser-firefox.applescript
default-browser-safari.applescript

The changes are identical in each:

I added a check for the current default browser. IF the current default browser is Chrome, the AppleScript needs to click button 1 of the confirmation dialog that appears when defaultbrowser is called (this is a change), otherwise it needs to click button 2 (the current action).

The reason for this is a difference in the order of the buttons on the dialog that appears if Chrome is the current default browser vs. the order if any other browser is default. Chrome's dialog has "change" as button 1 and "keep" as button 2, while the dialog for other browsers has them in the reverse order.

NOTE: I did not check Chromium so I don't know if this also applies to the case when Chromium is the default.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] New script command
- [x ] Bug fix
- [ ] Improvement of an existing script
- [ ] Documentation update
- [ ] Toolkit change
- [ ] Other (Specify)

## Screenshot

<!-- If it's a new script command, please include a screenshot or a GIF of how it works. -->

## Dependencies / Requirements

<!-- If it's a new script command that requires some additional steps to make it work, please describe it here. E.g. requiring installation of another command line tool or requirement to specify username / API token / etc. -->

## Checklist

- [x ] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)