### PR TITLE
feat(communication/slack): slack-dev-mode script

### DIFF
--- a/commands/communication/slack/slack-dev-mode.sh
+++ b/commands/communication/slack/slack-dev-mode.sh
@@ -2,7 +2,7 @@
 
 # Required parameters:
 # @raycast.schemaVersion 1
-# @raycast.title Slack Dev Mode
+# @raycast.title Launch Dev Mode
 # @raycast.mode silent
 
 # Optional parameters:

--- a/commands/communication/slack/slack-dev-mode.sh
+++ b/commands/communication/slack/slack-dev-mode.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Slack Dev Mode
+# @raycast.mode silent
+
+# Optional parameters:
+# @raycast.icon images/slack-logo.png
+# @raycast.packageName Slack
+
+# Documentation:
+# @raycast.description Open Slack with the Developer Menu enabled. ⌘⌥I to access the Developer Menu. If you find it's not working, quit Slack and run this command again.
+# @raycast.author Cody Carrell
+# @raycast.authorURL https://raycast.com/sourcecody
+
+SLACK_DEVELOPER_MENU=true open /Applications/Slack.app


### PR DESCRIPTION
## Description

<!-- Please write a short summary for this change. If it's a new script command, explain what it does. -->
This is a very simple command that launches Slack with the Developer Menu (Electron Dev Tools) enabled via `⌘+⌥+I`.
## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New script command

## Screenshot
<img width="750" alt="image" src="https://github.com/raycast/script-commands/assets/1896665/2671b33a-2ccc-4b11-8882-d226fb35afce">

<!-- If it's a new script command, please include a screenshot or a GIF of how it works. -->

## Dependencies / Requirements

<!-- If it's a new script command that requires some additional steps to make it work, please describe it here. E.g. requiring installation of another command line tool or requirement to specify username / API token / etc. -->

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)