### PR TITLE
[Apple Notes] Fixed title issue

### DIFF
--- a/commands/apps/notes/create-note-from-clipboard.applescript
+++ b/commands/apps/notes/create-note-from-clipboard.applescript
@@ -21,6 +21,6 @@ on run argv
 	</body>"
 tell application "Notes"
 		activate
-		make new note at folder "Notes" with properties {name: (item 1 of argv), body:content}
+		make new note at folder "Notes" with properties {name:"", body:content}
 	end tell
 end run


### PR DESCRIPTION
## Description

Fixed issue with double-pasting of titles.

<img width="930" alt="Screenshot 2024-03-01 at 12 45 38" src="https://github.com/raycast/script-commands/assets/85677120/d7617359-238e-41d7-a80e-d9a87474f91d">

<img width="1163" alt="Screenshot 2024-03-01 at 12 45 47" src="https://github.com/raycast/script-commands/assets/85677120/5b9d8381-b7e0-421a-9fad-af6bc0e55a76">

## Type of change

- [x] Bug fix

## Screenshot

PR sets title correctly:

<img width="1150" alt="Screenshot 2024-03-01 at 12 47 32" src="https://github.com/raycast/script-commands/assets/85677120/387e095e-a85c-4579-8be5-0966b9db9643">

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)