### PR TITLE
feat: adding show-notifications command

### DIFF
--- a/commands/system/show-notifications.applescript
+++ b/commands/system/show-notifications.applescript
@@ -1,0 +1,25 @@
+#!/usr/bin/osascript
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Show Notifications
+# @raycast.mode silent
+
+# Optional parameters:
+# @raycast.icon 🔕
+# @raycast.packageName System
+
+# Documentation:
+# @raycast.description Show all notification of the first alert group
+# @raycast.author iloveitaly
+# @raycast.authorURL github.com/iloveitaly
+
+tell application "System Events"
+	tell process "NotificationCenter"
+		if not (window "Notification Center" exists) then return
+		-- clicking on the notification group will expand it and show all sub messages
+		click of group 1 of UI element of scroll area of first group of window "Notification Center"
+		-- Show no message on success
+		return ""
+	end tell
+end tell


### PR DESCRIPTION
## Description

Applescript to expand notifications on macOS

## Type of change


- [x] New script command

## Screenshot

Run the script, notifications are expanded

## Dependencies / Requirements

None, `osascript` is bundled with macOS

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)
