### PR TITLE
Update default-browser-front-most-app - Firefoc dev and SigmaOS

### DIFF
--- a/commands/system/default-browser-front-most-app.applescript
+++ b/commands/system/default-browser-front-most-app.applescript
@@ -38,6 +38,8 @@ if (raycastArgv is equal to "") then
     set browserName to "safari"
   else if (appName is equal to "Safari Technology Preview") then
     set browserName to "safaritechnologypreview"
+  else if (appName contains "Firefox Dev") then
+    set browserName to "firefoxdeveloperedition"
   # set Google chrome dev as default browser
   # it need to put before Chrome
   else if (appName contains "dev") then
@@ -48,8 +50,8 @@ if (raycastArgv is equal to "") then
     set browserName to "chromium"
   else if (appName is equal to "Firefox") then
     set browserName to "firefox"
-  else if (appName is equal to "Firefox Developer Edition") then
-    set browserName to "firefoxdeveloperedition"
+  else if (appName is equal to "SigmaOS") then
+    set browserName to "macos"
   end if
 
 else

--- a/commands/system/default-browser-front-most-app.applescript
+++ b/commands/system/default-browser-front-most-app.applescript
@@ -52,6 +52,8 @@ if (raycastArgv is equal to "") then
     set browserName to "firefox"
   else if (appName is equal to "SigmaOS") then
     set browserName to "macos"
+  else if (appName is equal to "Arc") then
+    set browserName to "browser"
   end if
 
 else


### PR DESCRIPTION
## Description

Updated default-browser-front-most-app.applescript to fix a bug with Firefox Development Edition browser and add a new browser SigmaOS.

    - Firexfox Developer Edition was not working as chrome dev was catching any browser with dev in the name before it could get to firefox dev, moved firefox dev before chrome to allow both to catch properly.

    - Added SigmaOS to browser list.

## Type of change

- [x] Bug fix
- [x] Improvement of an existing script

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)