### PR TITLE
Fix: Natural Scrolling Script for latest macos versions

### DIFF
--- a/commands/system/toggle-natural-scrolling.applescript
+++ b/commands/system/toggle-natural-scrolling.applescript
@@ -12,18 +12,32 @@
 # @raycast.authorURL https://twitter.com/wileymarques
 # @raycast.description Script Command to change natural trackpad/mouse scrolling setting. Reverting the setting value each time.
 
-tell application "System Preferences"
-  activate
-  set current pane to pane "com.apple.preference.trackpad"
-end tell
+set macVersion to system version of (system info)
 
-delay 0.6
-
-tell application "System Events"
-  tell process "System Preferences"
-    click radio button 2 of tab group 1 of window "Trackpad"
-    click checkbox 1 of tab group 1 of window "Trackpad"
-  end tell
-end tell
-
-tell application "System Preferences" to quit
+if macVersion is greater than or equal to "14" then
+	set isNaturalScrolling to (do shell script "defaults -currentHost read NSGlobalDomain com.apple.swipescrolldirection")
+	
+	if isNaturalScrolling is "1" then
+		do shell script "defaults -currentHost write NSGlobalDomain com.apple.swipescrolldirection -bool NO"
+	else
+		do shell script "defaults -currentHost write NSGlobalDomain com.apple.swipescrolldirection -bool YES"
+	end if
+	
+	do shell script "/System/Library/PrivateFrameworks/SystemAdministration.framework/Resources/activateSettings -u"
+else
+	tell application "System Settings"
+		activate
+		set current pane to pane "com.apple.preference.trackpad"
+	end tell
+	
+	delay 0.6
+	
+	tell application "System Events"
+		tell process "System Preferences"
+			click radio button 2 of tab group 1 of window "Trackpad"
+			click checkbox 1 of tab group 1 of window "Trackpad"
+		end tell
+	end tell
+	
+	tell application "System Settings" to quit
+end if


### PR DESCRIPTION
## Description

The current natural scrolling script doesn't work in latest macos version 14 (Sonama). I think this has been broken for a while (after Ventura), based on my research, but I can't confirm it. This change fixes the script to work correctly for macos 14 (Sonama) and higher and keeps the old script for older versions. I think the same new script would work for older versions as well, but I can't test that, so I've kept the old script under the else block.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] New script command
- [x] Bug fix
- [ ] Improvement of an existing script
- [ ] Documentation update
- [ ] Toolkit change
- [ ] Other (Specify)

## Screenshot

<!-- If it's a new script command, please include a screenshot or a GIF of how it works. -->

## Dependencies / Requirements

<!-- If it's a new script command that requires some additional steps to make it work, please describe it here. E.g. requiring installation of another command line tool or requirement to specify username / API token / etc. -->

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)