### PR TITLE
Script for convert Markdown formatting to Telegram format

### DIFF
--- a/commands/conversions/markdown-to-telegram.py
+++ b/commands/conversions/markdown-to-telegram.py
@@ -7,7 +7,7 @@
 
 # Optional parameters:
 # @raycast.icon 🔄
-# @raycast.packageName Content Tools
+# @raycast.packageName Conversions
 # @raycast.description Convert Markdown formatting to Telegram format, excluding processing inside code blocks or quotes
 
 # Documentation:

--- a/commands/conversions/markdown-to-telegram.py
+++ b/commands/conversions/markdown-to-telegram.py
@@ -23,7 +23,7 @@ def paste():
     return subprocess.check_output('pbpaste', env=env_vars).decode(encoding)
 
 def copy(text):
-    process = subprocess.Popen('pbcopy', env={'LANG': 'en_US.UTF-8'}, stdin=subprocess.PIPE)
+    process = subprocess.Popen('pbcopy', env=env_vars, stdin=subprocess.PIPE)
     process.communicate(text.encode('utf-8'))
 
 def convert_markdown(text):

--- a/commands/conversions/markdown-to-telegram.py
+++ b/commands/conversions/markdown-to-telegram.py
@@ -16,6 +16,8 @@
 import re
 import subprocess
 
+env_vars = {'LANG': 'en_US.UTF-8'}
+encoding = 'utf-8'
 def paste():
     return subprocess.check_output('pbpaste', env={'LANG': 'en_US.UTF-8'}).decode('utf-8')
 

--- a/commands/conversions/markdown-to-telegram.py
+++ b/commands/conversions/markdown-to-telegram.py
@@ -12,6 +12,7 @@
 
 # Documentation:
 # @raycast.author Maxim Borzov
+# @raycast.authorURL https://github.com/borzov
 
 import re
 import subprocess

--- a/commands/conversions/markdown-to-telegram.py
+++ b/commands/conversions/markdown-to-telegram.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Convert Markdown to Telegram Format
+# @raycast.mode silent
+
+# Optional parameters:
+# @raycast.icon 🔄
+# @raycast.packageName Content Tools
+# @raycast.description Convert Markdown formatting to Telegram format, excluding processing inside code blocks or quotes
+
+# Documentation:
+# @raycast.author Maxim Borzov
+
+import re
+import subprocess
+
+def paste():
+    return subprocess.check_output('pbpaste', env={'LANG': 'en_US.UTF-8'}).decode('utf-8')
+
+def copy(text):
+    process = subprocess.Popen('pbcopy', env={'LANG': 'en_US.UTF-8'}, stdin=subprocess.PIPE)
+    process.communicate(text.encode('utf-8'))
+
+def convert_markdown(text):
+    lines = text.split('\n')
+    converted_lines = []
+    in_code_block = False
+
+    for line in lines:
+        if line.startswith('```'):
+            in_code_block = not in_code_block
+            converted_lines.append(line)
+            continue
+
+        if not in_code_block and not line.startswith('>'):  # Skip quotes
+            # Format headers
+            if line.startswith('# '):
+                line = f"🔰 **{line[2:].strip()}**\n"
+            elif line.startswith('## '):
+                line = f"📌 **{line[3:].strip()}**\n"
+            elif line.startswith('### '):
+                line = f"🔹 **{line[4:].strip()}**\n"
+            elif line.startswith('#### '):
+                line = f"▪️ **{line[5:].strip()}**\n"
+            elif line.startswith('##### '):
+                line = f"◾️ **{line[6:].strip()}**\n"
+            elif line.startswith('###### '):
+                line = f"⚫️ **{line[7:].strip()}**\n"
+            else:  # Only format if not a header
+                line = re.sub(r'(?<!\\)\*{2}(.*?)\*{2}', r'**\1**', line)  # Bold
+                line = re.sub(r'(?<!\\)_{2}(.*?)_{2}', r'**\1**', line)  # Also bold
+                line = re.sub(r'(?<!\\|\*)\*(?!\*)(.+?)(?<!\*)\*(?![\*_])', r'__\1__', line)  # Italic
+                line = re.sub(r'(?<!\\|_)_(?!_)(.+?)(?<!_)_(?![\*_])', r'__\1__', line)  # Also italic
+                line = re.sub(r'(?<!\\)~{2}(.*?)~{2}', r'~~\1~~', line)  # Strikethrough
+                line = re.sub(r'(?<!\\)\|\|(.*?)\|\|', r'||\1||', line)  # Spoiler
+                line = re.sub(r'(?<!\\)-{2}(.*?)-{2}', r'--\1--', line)  # Underline
+                line = re.sub(r'(?<!\\)\[(.*?)\]\((.*?)\)', r'[\1](\2)', line)  # Links
+                line = re.sub(r'(?<!\\)`(.*?)`', r'`\1`', line)  # Inline code
+
+        converted_lines.append(line)
+
+    # Add empty lines between paragraphs
+    result = []
+    for i in range(len(converted_lines)):
+        result.append(converted_lines[i])
+        if i < len(converted_lines) - 1:
+            cur = converted_lines[i].strip()
+            next = converted_lines[i+1].strip()
+            if cur and next and not cur.startswith(('*', '-', '```', '|', '>')) and not next.startswith(('*', '-', '```', '|', '>')):
+                result.append('')
+
+    return '\n'.join(result)
+
+if __name__ == "__main__":
+    try:
+        markdown_text = paste()
+        converted_text = convert_markdown(markdown_text)
+        copy(converted_text)
+        print("✅ Markdown converted and copied to clipboard")
+    except Exception as e:
+        print(f"❌ Error during conversion: {str(e)}")

--- a/commands/conversions/markdown-to-telegram.py
+++ b/commands/conversions/markdown-to-telegram.py
@@ -20,7 +20,7 @@ import subprocess
 env_vars = {'LANG': 'en_US.UTF-8'}
 encoding = 'utf-8'
 def paste():
-    return subprocess.check_output('pbpaste', env={'LANG': 'en_US.UTF-8'}).decode('utf-8')
+    return subprocess.check_output('pbpaste', env=env_vars).decode(encoding)
 
 def copy(text):
     process = subprocess.Popen('pbcopy', env={'LANG': 'en_US.UTF-8'}, stdin=subprocess.PIPE)

--- a/commands/conversions/markdown-to-telegram.py
+++ b/commands/conversions/markdown-to-telegram.py
@@ -17,50 +17,64 @@
 import re
 import subprocess
 
+# Set environment variables and encoding
 env_vars = {'LANG': 'en_US.UTF-8'}
 encoding = 'utf-8'
+
 def paste():
+    """Read text from the clipboard."""
     return subprocess.check_output('pbpaste', env=env_vars).decode(encoding)
 
 def copy(text):
+    """Write text to the clipboard."""
     process = subprocess.Popen('pbcopy', env=env_vars, stdin=subprocess.PIPE)
     process.communicate(text.encode(encoding))
 
 def convert_markdown(text):
+    """Convert Markdown formatting to Telegram format."""
     lines = text.split('\n')
     converted_lines = []
     in_code_block = False
 
     for line in lines:
+        # Check if the line is a code block delimiter
         if line.startswith('```'):
             in_code_block = not in_code_block
             converted_lines.append(line)
             continue
 
-        if not in_code_block and not line.startswith('>'):  # Skip quotes
-            # Format headers
+        # Skip quotes and only format if not in a code block
+        if not in_code_block and not line.startswith('>'):
+            # Format headers with emojis and bold text
             if line.startswith('# '):
-                line = f"🔰 **{line[2:].strip()}**\n"
+                line = f"⚫️ **{line[2:].strip()}**\n"
             elif line.startswith('## '):
-                line = f"📌 **{line[3:].strip()}**\n"
+                line = f"◾️ **{line[3:].strip()}**\n"
             elif line.startswith('### '):
-                line = f"🔹 **{line[4:].strip()}**\n"
+                line = f"▪️ **{line[4:].strip()}**\n"
             elif line.startswith('#### '):
-                line = f"▪️ **{line[5:].strip()}**\n"
+                line = f"🔹 **{line[5:].strip()}**\n"
             elif line.startswith('##### '):
-                line = f"◾️ **{line[6:].strip()}**\n"
+                line = f"📌 **{line[6:].strip()}**\n"
             elif line.startswith('###### '):
-                line = f"⚫️ **{line[7:].strip()}**\n"
-            else:  # Only format if not a header
-                line = re.sub(r'(?<!\\)\*{2}(.*?)\*{2}', r'**\1**', line)  # Bold
-                line = re.sub(r'(?<!\\)_{2}(.*?)_{2}', r'**\1**', line)  # Also bold
-                line = re.sub(r'(?<!\\|\*)\*(?!\*)(.+?)(?<!\*)\*(?![\*_])', r'__\1__', line)  # Italic
-                line = re.sub(r'(?<!\\|_)_(?!_)(.+?)(?<!_)_(?![\*_])', r'__\1__', line)  # Also italic
-                line = re.sub(r'(?<!\\)~{2}(.*?)~{2}', r'~~\1~~', line)  # Strikethrough
-                line = re.sub(r'(?<!\\)\|\|(.*?)\|\|', r'||\1||', line)  # Spoiler
-                line = re.sub(r'(?<!\\)-{2}(.*?)-{2}', r'--\1--', line)  # Underline
-                line = re.sub(r'(?<!\\)\[(.*?)\]\((.*?)\)', r'[\1](\2)', line)  # Links
-                line = re.sub(r'(?<!\\)`(.*?)`', r'`\1`', line)  # Inline code
+                line = f"🔰 **{line[7:].strip()}**\n"
+            else:
+                # Format bold text
+                line = re.sub(r'(?<!\\)\*{2}(.*?)\*{2}', r'**\1**', line)
+                line = re.sub(r'(?<!\\)_{2}(.*?)_{2}', r'**\1**', line)
+                # Format italic text
+                line = re.sub(r'(?<!\\|\*)\*(?!\*)(.+?)(?<!\*)\*(?![\*_])', r'__\1__', line)
+                line = re.sub(r'(?<!\\|_)_(?!_)(.+?)(?<!_)_(?![\*_])', r'__\1__', line)
+                # Format strikethrough text
+                line = re.sub(r'(?<!\\)~{2}(.*?)~{2}', r'~~\1~~', line)
+                # Format spoilers
+                line = re.sub(r'(?<!\\)\|\|(.*?)\|\|', r'||\1||', line)
+                # Format underline text
+                line = re.sub(r'(?<!\\)-{2}(.*?)-{2}', r'--\1--', line)
+                # Format links
+                line = re.sub(r'(?<!\\)\[(.*?)\]\((.*?)\)', r'[\1](\2)', line)
+                # Format inline code
+                line = re.sub(r'(?<!\\)`(.*?)`', r'`\1`', line)
 
         converted_lines.append(line)
 

--- a/commands/conversions/markdown-to-telegram.py
+++ b/commands/conversions/markdown-to-telegram.py
@@ -24,7 +24,7 @@ def paste():
 
 def copy(text):
     process = subprocess.Popen('pbcopy', env=env_vars, stdin=subprocess.PIPE)
-    process.communicate(text.encode('utf-8'))
+    process.communicate(text.encode(encoding))
 
 def convert_markdown(text):
     lines = text.split('\n')


### PR DESCRIPTION
## Description

This script converts Markdown-formatted text into a Telegram-compatible format. It automatically transforms various Markdown formatting elements, such as headers, bold, italic, strikethrough, spoilers, underline, links, and inline code, into their corresponding Telegram formatting tags. The script also adds emojis before different header levels and inserts empty lines between paragraphs to improve readability.

This tool is particularly useful for those who frequently work with Markdown documentation and want to quickly share it on Telegram while preserving most of the original formatting. Instead of manually altering the syntax for each formatting element, users can simply copy their Markdown text, run this script, and have the formatted version ready to paste directly into a Telegram chat, saving time and effort.

## Type of change

- [Х] New script command

## Dependencies / Requirements

The script relies on the following built-in Python libraries for its functionality on macOS:

1. `re`: This library is used for regular expressions, which are essential for searching and replacing Markdown formatting elements with their Telegram counterparts.

2. `subprocess`: This library is used to interact with the macOS clipboard through the `pbpaste` and `pbcopy` command-line utilities. It allows the script to read Markdown text from the clipboard and write the converted text back to the clipboard.

No additional third-party libraries are required, as the script utilizes the built-in `re` and `subprocess` libraries, making it easy to set up and use on macOS systems with Python installed.

## Checklist

- [X] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)