### PR TITLE
Fix: ocr command by updating recognitionlangues params

### DIFF
--- a/commands/system/ocr.swift
+++ b/commands/system/ocr.swift
@@ -21,7 +21,7 @@ import Cocoa
 import Vision
 
 let screenCapturePath = "/tmp/ocr.png"
-let recognitionLanguages = ["en-US", "zh-CN"]
+let recognitionLanguages = ["zh-Hans", "en-US"]
 let joiner = " "
 
 @discardableResult


### PR DESCRIPTION


## Description

<!-- Please write a short summary for this change. If it's a new script command, explain what it does. -->
Previously, Chinese could not be recognized by OCR, it was all garbled.
Correct the OCR command by updating the 'recognition languages' parameters; this will ensure both Chinese and English are recognized accurately.

Reference:
To recognize traditional and simplified Chinese, specify zh-Hant and zh-Hans as the first elements in the request’s recognitionLanguages property. English is the only other language that you can pair with Chinese. https://developer.apple.com/documentation/vision/original_objective-c_and_swift_api/recognizing_text_in_images

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix

## Screenshot

<!-- If it's a new script command, please include a screenshot or a GIF of how it works. -->

## Dependencies / Requirements

<!-- If it's a new script command that requires some additional steps to make it work, please describe it here. E.g. requiring installation of another command line tool or requirement to specify username / API token / etc. -->

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)