### PR TITLE
Remove superfluous period from all script template renaming instructions

### DIFF
--- a/templates/script-command.template.applescript
+++ b/templates/script-command.template.applescript
@@ -2,7 +2,7 @@
 
 # Raycast Script Command Template
 #
-# Duplicate this file and remove ".template." from the filename to get started.
+# Duplicate this file and remove ".template" from the filename to get started.
 # See full documentation here: https://github.com/raycast/script-commands
 #
 # Required parameters:

--- a/templates/script-command.template.php
+++ b/templates/script-command.template.php
@@ -5,7 +5,7 @@
 # Dependency: This script requires PHP
 # Install PHP: http://www.https://www.php.net/
 #
-# Duplicate this file and remove ".template." from the filename to get started.
+# Duplicate this file and remove ".template" from the filename to get started.
 # See full documentation here: https://github.com/raycast/script-commands
 #
 # Required parameters:

--- a/templates/script-command.template.py
+++ b/templates/script-command.template.py
@@ -5,7 +5,7 @@
 # Dependency: This script requires Python 3
 # Install Python 3: https://www.python.org/downloads/release
 #
-# Duplicate this file and remove ".template." from the filename to get started.
+# Duplicate this file and remove ".template" from the filename to get started.
 # See full documentation here: https://github.com/raycast/script-commands
 #
 # Required parameters:

--- a/templates/script-command.template.rb
+++ b/templates/script-command.template.rb
@@ -5,7 +5,7 @@
 # Dependency: This script requires Ruby
 # Install Ruby: http://www.ruby-lang.org/
 #
-# Duplicate this file and remove ".template." from the filename to get started.
+# Duplicate this file and remove ".template" from the filename to get started.
 # See full documentation here: https://github.com/raycast/script-commands
 #
 # Required parameters:

--- a/templates/script-command.template.sh
+++ b/templates/script-command.template.sh
@@ -2,7 +2,7 @@
 
 # Raycast Script Command Template
 #
-# Duplicate this file and remove ".template." from the filename to get started.
+# Duplicate this file and remove ".template" from the filename to get started.
 # See full documentation here: https://github.com/raycast/script-commands
 #
 # Required parameters:

--- a/templates/script-command.template.swift
+++ b/templates/script-command.template.swift
@@ -2,7 +2,7 @@
 
 // Raycast Script Command Template
 // 
-// Duplicate this file and remove ".template." from the filename to get started.
+// Duplicate this file and remove ".template" from the filename to get started.
 // See full documentation here: https://github.com/raycast/script-commands
 //
 // Required parameters:


### PR DESCRIPTION
## Description

In the instruction comments for each script template there is a comment that says:

`// Duplicate this file and remove ".template." from the filename to get started.`

The full file path is, for example, `../raycast scripts/script-command.template.sh` so following this instruction as is would result (undesirebly) in:

`../raycast scripts/script-commandsh`

which isn't a valid file. So the instruction should be:

`// Duplicate this file and remove ".template" from the filename to get started.`

The .js file templates/script-command.template.js did not have this issue so it is not touched in this commit/PR.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] New script command
- [ ] Bug fix
- [ ] Improvement of an existing script
- [X] Documentation update
- [ ] Toolkit change
- [ ] Other (Specify)

## Screenshot

n/a

## Dependencies / Requirements

n/a

## Checklist

- [X] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)