### PR TITLE
Add Open ChatGPT script

### DIFF
--- a/commands/apps/chatgpt/open-chatgpt.sh
+++ b/commands/apps/chatgpt/open-chatgpt.sh
@@ -9,7 +9,7 @@
 # @raycast.icon 🤖
 
 # Documentation:
-# @raycast.description Opens the macOS ChatGPT app if it's not running already. If it's already running, then it justs invokes the ChatGPT via the `⌥+Space` hotkey. ⚠️ Note: Please assign this script command the `⌥+Space` hotkey in Raycast for this to work as expected.
+# @raycast.description It opens the macOS ChatGPT app if it's not running already. If it's already running, then it just invokes the ChatGPT via the `⌥+Space` hotkey. ⚠️ Note: Please assign this script the `⌥+Space` hotkey in Raycast for this to work as expected.
 # @raycast.author luiscarlospando
 # @raycast.authorURL https://raycast.com/luiscarlospando
 

--- a/commands/apps/chatgpt/open-chatgpt.sh
+++ b/commands/apps/chatgpt/open-chatgpt.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-# Note: ChatGPT for macOS required
-# Download it via OpenAI website: https://openai.com/chatgpt/mac/
-
 # Required parameters:
 # @raycast.schemaVersion 1
 # @raycast.title Open ChatGPT
@@ -12,7 +9,7 @@
 # @raycast.icon 🤖
 
 # Documentation:
-# @raycast.description It opens the macOS ChatGPT app if it's not running already. If it's already running, then it just invokes the ChatGPT via the `⌥+Space` hotkey. ⚠️ Note: Please assign this script the `⌥+Space` hotkey in Raycast for this to work as expected.
+# @raycast.description It opens the macOS ChatGPT app if it's not running already. If it's already running, then it just invokes the ChatGPT via the `⌥+Space` hotkey. ⚠️ Note: Although is not mandatory it's recommended to assign the `⌥+Space` hotkey to this script in Raycast only for it to work as intended.
 # @raycast.author luiscarlospando
 # @raycast.authorURL https://raycast.com/luiscarlospando
 

--- a/commands/apps/chatgpt/open-chatgpt.sh
+++ b/commands/apps/chatgpt/open-chatgpt.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Open ChatGPT
+# @raycast.mode silent
+
+# Optional parameters:
+# @raycast.icon 🤖
+
+# Documentation:
+# @raycast.description Opens the macOS ChatGPT app if it's not running already. If it's already running, then it justs invokes the ChatGPT via the `⌥+Space` hotkey. ⚠️ Note: Please assign this script command the `⌥+Space` hotkey in Raycast for this to work as expected.
+# @raycast.author luiscarlospando
+# @raycast.authorURL https://raycast.com/luiscarlospando
+
+APP_NAME="ChatGPT"
+
+if pgrep -x "$APP_NAME" > /dev/null
+then
+    exit 0
+else
+    open -a "$APP_NAME"
+fi

--- a/commands/apps/chatgpt/open-chatgpt.sh
+++ b/commands/apps/chatgpt/open-chatgpt.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Note: ChatGPT for macOS required
+# Download it via OpenAI website: https://openai.com/chatgpt/mac/
+
 # Required parameters:
 # @raycast.schemaVersion 1
 # @raycast.title Open ChatGPT


### PR DESCRIPTION
## Description

It opens the macOS ChatGPT app if it's not running already. If it's already running, then it just invokes the ChatGPT via the `⌥+Space` hotkey.

⚠️ Note: Although is not mandatory it's recommended to assign the `⌥+Space` hotkey to this script in Raycast only for it to work as intended.

## Type of change

- [x] New script command

## Screenshot

### Opens the ChatGPT app if it's not currently running
![CleanShot 2024-07-02 at 9  57 57](https://github.com/raycast/script-commands/assets/433549/2c596dfc-7a5f-4de0-a164-266281132e10)

### Invokes the ChatGPT app if it's already running
![CleanShot 2024-07-02 at 9  59 09](https://github.com/raycast/script-commands/assets/433549/a7a5c43a-5b14-4c51-96e5-060ce46749eb)

## Dependencies / Requirements

This script requires the macOS ChatGPT app which can be downloaded via [the Open IA website](https://openai.com/chatgpt/mac/).

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)