### PR TITLE
fix(duckduckgo-email-protection): address parsing

### DIFF
--- a/commands/communication/duckduckgo-email-protection/generate-unique-email-address.applescript
+++ b/commands/communication/duckduckgo-email-protection/generate-unique-email-address.applescript
@@ -17,7 +17,7 @@
 on run
 	set prefix to do shell script "curl -X POST https://quack.duckduckgo.com/api/email/addresses --header 'Authorization: Bearer " & getAuthorizationID() & "'"
 	if text 3 through 9 of prefix is "address" then
-		set uniqueAddress to text 13 through 20 of prefix & "@duck.com"
+		set uniqueAddress to text 13 through -3 of prefix & "@duck.com"
 		set the clipboard to uniqueAddress
 		return uniqueAddress & " copied to clipboard!"
 	else


### PR DESCRIPTION
## Description

<!-- Please write a short summary for this change. If it's a new script command, explain what it does. -->

DuckDuckGo has modified its generated email addresses, and they will now follow the format three-word-addresses@duck.com instead of the previous fixed-length format (e.g. vcb35uk3@duck.com).

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)