### PR TITLE
Hide Application

### DIFF
--- a/commands/navigation/hide-application.applescript
+++ b/commands/navigation/hide-application.applescript
@@ -1,0 +1,18 @@
+#!/usr/bin/osascript
+
+# @raycast.schemaVersion 1
+# @raycast.author Chris Bailey
+# @raycast.authorURL https://raycast.com/that70schris
+# @raycast.description Easily hide your foremost application
+# @raycast.packageName Navigation
+# @raycast.title Hide Current Application
+# @raycast.mode silent
+# @raycast.icon 🫥
+
+tell application "System Events"
+	tell (first process whose frontmost is true)
+		set _name to displayed name
+	end tell
+
+  set visible of application process _name to false
+end tell


### PR DESCRIPTION
## Description

<!-- Please write a short summary for this change. If it's a new script command, explain what it does. -->
This command hides the frontmost app.  This is useful if you want to remap the default Hide menu command keyboard shortcut: `command + h`.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New script command

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)