### PR TITLE
[script] Tailscale Switch: Make it switch account without logout

### DIFF
--- a/commands/apps/tailscale/tailscale-switch.sh
+++ b/commands/apps/tailscale/tailscale-switch.sh
@@ -29,12 +29,11 @@ else
   exit 1
 fi
 
-$ts logout
-$ts up
+"${ts}" switch --list |     # List all Tailscale accounts "<ID>  <Tailnet name>  <User account name>"
+grep -vF -e 'ID' -e '*' |   # Omit the header line and the current account marked with "*"
+awk '{ print $1 }' |        # Print only the account ID of not-connected accounts
+head -n1 |                  # Print only the first not-connected account
+xargs -r -n1 "${ts}" switch # Switch to the selected account
 
-if command -v jq &> /dev/null; then
-  account=$($ts status --json | jq -r '.User[(.Self.UserID | tostring)].LoginName')
-  echo "Connected as $account"
-else
-  echo "Connected"
-fi
+tailnet="$("${ts}" switch --list | awk '/\*/ { print $2 }')"
+echo "Switched to ${tailnet}"


### PR DESCRIPTION
## Description

Update script tailscale-switch.sh to switch to another Tailscale account without logging out of the current account.

With two logged-in Tailscale accounts, the updated script allows switching between the two accounts without any re-authentication (as far as tested for the duration of ~17 hours after login to my accounts).

The script uses `tailscale switch --list` to list the available accounts. It takes the first not-connected account, and switches to this account with `tailscale switch ID`.

```console
$ tailscale switch --list
ID    Tailnet                    Account
e163  tailnet-a                  account-a@tailnet-a.example
2b13  tailnet-b                  account-b@tailnet-b.example
```

```console
$ tailscale switch 2b13
Switching to account "2b13"
Success.
```

## Type of change

- [ ] New script command
- [ ] Bug fix
- [x] Improvement of an existing script
- [ ] Documentation update
- [ ] Toolkit change
- [ ] Other (Specify)

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)