### PR TITLE
fix(rich-text-clipboard-to-markdown.sh): execution error

### DIFF
--- a/commands/conversions/rich-text-clipboard-to-markdown.sh
+++ b/commands/conversions/rich-text-clipboard-to-markdown.sh
@@ -20,4 +20,4 @@ if ! command -v pandoc &> /dev/null; then
 fi
 
 export LC_CTYPE=UTF-8
-osascript -e 'the clipboard as "HTML"'| perl -ne 'print chr foreach unpack("C*",pack("H*",substr($_,11,-3)))' | pandoc --from=html --to=gfm | pbcopy
+osascript -e 'the clipboard as «class RTF »' | perl -ne 'print chr foreach unpack("C*",pack("H*",substr($_,11,-3)))' | pandoc --from=rtf --to=gfm | pbcopy


### PR DESCRIPTION
## Description

<!-- Please write a short summary for this change. If it's a new script command, explain what it does. -->

Fix the error of executing rich-text-clipboard-to-markdown.sh according to [stackoverflow](https://stackoverflow.com/questions/2545289/getting-rtf-data-out-of-mac-os-x-pasteboard-clipboard).

```
0:23: execution error: Can’t make some data into the expected type. (-1700)
```

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix

## Screenshot

<!-- If it's a new script command, please include a screenshot or a GIF of how it works. -->

<img width="547" alt="Screenshot 2024-08-28 at 20 52 31" src="https://github.com/user-attachments/assets/bfd8e028-8ecf-4e77-8149-234c95f4bda8">

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)