### PR TITLE
Fix typo "ANSII"

### DIFF
--- a/documentation/OUTPUTMODES.md
+++ b/documentation/OUTPUTMODES.md
@@ -23,7 +23,7 @@ In `inline` mode, the first line of output will be directly shown in the command
 
 Please note that long-running tasks generating a lot of partial data are not supported for `compact`, `silent`, and `inline` modes. For example, the `zip` command generates a lot of partial logs when compressing folders with many files. Scripts using `zip` won't work on `compact`, `silent`, and `inline`; but they will work in `fullOutput`. To make it work in the other modes you need to use the `zip -q` flag.
 
-# ANSII Supported Colors 🎨
+# ANSI Supported Colors 🎨
 
 We support colors for `inline` and `fullOutput` mode scripts for you to customize generated output by changing its background and foreground color.
 


### PR DESCRIPTION
## Description

Fixes a typo; we're probably referring to [ANSI colors](https://en.wikipedia.org/wiki/ANSI_escape_code#Colors).

## Type of change

- [x] Documentation update

## Screenshot

–

## Dependencies / Requirements

–

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)