### PR TITLE
Add OPT command (One-Time Password) in system folder

### DIFF
--- a/commands/system/otp.sh
+++ b/commands/system/otp.sh
@@ -10,10 +10,10 @@
 # Optional parameters:
 # @raycast.icon 🔑
 # @raycast.packageName System
-# @raycast.argument1 { "type": "text", "placeholder": "domain" }
-# @raycast.argument2 { "type": "text", "placeholder": "username index", "optional": true }
+# @raycast.argument1 { "type": "text", "placeholder": "Domain" }
+# @raycast.argument2 { "type": "text", "placeholder": "Username Index", "optional": true }
 #
-# @raycast.description Get OTP (One-Time Password) from Apple Password Manager
+# @raycast.description Get One-Time Password (OTP) from Apple Password Manager
 # @raycast.author Angelos Michalopoulos
 # @raycase.authorURL https://github.com/miagg
 
@@ -26,20 +26,21 @@ CODES=$(apw otp get "$1" 2>/dev/null)
 STATUS=$?
 # ✋ If return code 9, not authenticated, run apw auth
 if [ $STATUS -eq 9 ]; then
-    apw auth
-    CODES=$(apw otp get "$1")
+    echo "Please authenticate first by running 'apw auth'"
+    exit 1
 fi
 # ✋ If return code 3, domain not found, alert user
 if [ $STATUS -eq 3 ]; then
-    echo "Domain not found"
+    echo "Domain $1 not found"
     exit 1
 fi
 # Grab available OTP codes for domain
-if [ $(echo $CODES | jq '.results | length') -gt 1 ]; then
+CODES_COUNT=$(echo $CODES | jq '.results | length')
+if [ $CODES_COUNT -gt 1 ]; then
     CODE=$(echo $CODES | jq -r ".results[$UINDEX].code")
     USERNAME=$(echo $CODES | jq -r ".results[$UINDEX].username")
     if [ "$CODE" == "null" ]; then
-        echo "Index out of range"
+        echo "Please provide an index between 1 and $CODES_COUNT"
         exit 1
     fi
 else

--- a/commands/system/otp.sh
+++ b/commands/system/otp.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# Dependency: This script requires `apw`, `jq` and `awk` to be installed and in $PATH
+#
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title One-Time Password
+# @raycast.mode silent
+#
+# Optional parameters:
+# @raycast.icon 🔑
+# @raycast.packageName System
+# @raycast.argument1 { "type": "text", "placeholder": "domain" }
+# @raycast.argument2 { "type": "text", "placeholder": "username index", "optional": true }
+#
+# @raycast.description Get OTP (One-Time Password) from Apple Password Manager
+# @raycast.author Angelos Michalopoulos
+# @raycase.authorURL https://github.com/miagg
+
+if ! command -v apw &> /dev/null || ! command -v jq &> /dev/null || ! command -v awk &> /dev/null; then
+    echo "This function requires apw, jq and awk to be installed"
+    exit 1
+fi
+UINDEX=$((${2:-1} - 1))
+CODES=$(apw otp get "$1" 2>/dev/null)
+STATUS=$?
+# ✋ If return code 9, not authenticated, run apw auth
+if [ $STATUS -eq 9 ]; then
+    apw auth
+    CODES=$(apw otp get "$1")
+fi
+# ✋ If return code 3, domain not found, alert user
+if [ $STATUS -eq 3 ]; then
+    echo "Domain not found"
+    exit 1
+fi
+# Grab available OTP codes for domain
+if [ $(echo $CODES | jq '.results | length') -gt 1 ]; then
+    CODE=$(echo $CODES | jq -r ".results[$UINDEX].code")
+    USERNAME=$(echo $CODES | jq -r ".results[$UINDEX].username")
+    if [ "$CODE" == "null" ]; then
+        echo "Index out of range"
+        exit 1
+    fi
+else
+    CODE=$(echo $CODES | jq -r '.results[0].code')
+    USERNAME=$(echo $CODES | jq -r ".results[0].username")
+fi
+echo $CODE | pbcopy
+echo "OTP code for $USERNAME copied to clipboard"


### PR DESCRIPTION
## Description

This command copies One-Time Password for specified domain from Apple Password Manager.

## Type of change

- [x] New script command

## Screenshot

![](https://b2.apptime.gr/file/apptime/Screen-Recording-2024-10-31-14-42-12.gif)

## Dependencies / Requirements

Requires installation of [Apple Passwords CLI](https://github.com/bendews/apw) wrapper of Apple Passwords Manager.
It also requires `jq` that can be also installed from homebrew.

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)