### PR TITLE
add lowfi command

### DIFF
--- a/commands/media/lowfi/lowfi.sh
+++ b/commands/media/lowfi/lowfi.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# Note: WezTerm required
+# Install at https://wezfurlong.org/wezterm/install/macos.html
+# or by homebrew: brew install --cask wezterm
+
 # Required parameters:
 # @raycast.schemaVersion 1
 # @raycast.title Lowfi

--- a/commands/media/lowfi/lowfi.sh
+++ b/commands/media/lowfi/lowfi.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 
-# Note: WezTerm required
-# Install at https://wezfurlong.org/wezterm/install/macos.html
+# Note: lowfi and WezTerm required
+#
+# Install lowfi at https://github.com/talwat/lowfi
+# or by cargo: cargo install lowfi
+#
+# Install WezTerm at https://wezfurlong.org/wezterm/install/macos.html
 # or by homebrew: brew install --cask wezterm
 
 # Required parameters:
@@ -18,7 +22,7 @@ export PATH="$HOME/.cargo/bin:$PATH"
 # Check if lowfi is already running
 if pgrep -f "lowfi$" > /dev/null; then
     echo "Found existing lowfi process"
-    
+
     # Use AppleScript to find and focus the lowfi window
     osascript -e '
         -- First activate WezTerm application

--- a/commands/media/lowfi/lowfi.sh
+++ b/commands/media/lowfi/lowfi.sh
@@ -51,5 +51,5 @@ if pgrep -f "lowfi$" > /dev/null; then
     '
 else
     echo "Starting new lowfi instance"
-    /Applications/WezTerm.app/Contents/MacOS/wezterm start -- lowfi
+    /Applications/WezTerm.app/Contents/MacOS/wezterm start -- lowfi &
 fi

--- a/commands/media/lowfi/lowfi.sh
+++ b/commands/media/lowfi/lowfi.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Lowfi
+# @raycast.mode compact
+# @raycast.packageName Music
+
+# Optional parameters:
+# @raycast.icon
+
+export PATH="$HOME/.cargo/bin:$PATH"
+
+# Check if lowfi is already running
+if pgrep -f "lowfi$" > /dev/null; then
+    echo "Found existing lowfi process"
+    
+    # Use AppleScript to find and focus the lowfi window
+    osascript -e '
+        -- First activate WezTerm application
+        tell application "WezTerm" to activate
+        
+        -- Then focus the specific window
+        tell application "System Events"
+            tell process "wezterm-gui"
+                -- Get all windows
+                set allWindows to every window
+                repeat with w in allWindows
+                    if title of w contains "lowfi" then
+                        -- Try multiple methods to bring window to front
+                        set frontmost to true
+                        set value of attribute "AXMain" of w to true
+                        perform action "AXRaise" of w
+                        set position of w to {0, 40}
+                        -- Click the window to ensure focus
+                        click w
+                        return "Found and focused lowfi window"
+                    end if
+                end repeat
+            end tell
+        end tell
+        return "Could not find lowfi window"
+    '
+else
+    echo "Starting new lowfi instance"
+    /Applications/WezTerm.app/Contents/MacOS/wezterm start -- lowfi
+fi


### PR DESCRIPTION
## Description

<!-- Please write a short summary for this change. If it's a new script command, explain what it does. -->
Script command for start [lowfi](https://github.com/talwat/lowfi) command in a wezterm window, run the second time to bring the lowfi window to the front

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New script command

## Screenshot

<!-- If it's a new script command, please include a screenshot or a GIF of how it works. -->
<img width="787" alt="Untitled" src="https://github.com/user-attachments/assets/1bec90f0-e6b5-4fb0-b89d-cdaba223917e">



## Dependencies / Requirements

<!-- If it's a new script command that requires some additional steps to make it work, please describe it here. E.g. requiring installation of another command line tool or requirement to specify username / API token / etc. -->

Require
- [lowfi](https://github.com/talwat/lowfi)
- [WezTerm](https://wezfurlong.org/wezterm/index.html)


## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)