### PR TITLE
allow only second argument

### DIFF
--- a/commands/web-searches/google-maps.sh
+++ b/commands/web-searches/google-maps.sh
@@ -14,10 +14,14 @@
 first_argument=${1// /+}
 second_argument=${2// /+}
 
-if [ "$1" = "" ]; then
-	open "https://www.google.com/maps"
-elif [ "$2" = "" ]; then
-	open "https://www.google.com/maps/search/$first_argument"
+if [ "$1" != "" ]; then
+        if [ "$2" = "" ]; then
+                open "https://www.google.com/maps/dir/?api=1&origin=$first_argument"
+        else
+                open "https://www.google.com/maps/dir/?api=1&origin=$first_argument&destination=$second_argument"
+        fi
+elif [ "$1" = "" ] && [ "$2" != "" ]; then
+        open "https://www.google.com/maps/dir/?api=1&origin=Current+Location&destination=$second_argument"
 else
-	open "https://www.google.com/maps/dir/$first_argument/$second_argument"
+        open "https://www.google.com/maps"
 fi


### PR DESCRIPTION
## Description

- allow to omit first argument in favor of automatic "current location"
- use api to allow origin and destination as separate optional arguments
- reverse logic to use normal maps as fallback if no parameters are given

## Type of change

- [x] Improvement of an existing script

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)