### PR TITLE
Update dismiss-notifications.applescript to work on Sequoia

### DIFF
--- a/commands/system/dismiss-notifications.applescript
+++ b/commands/system/dismiss-notifications.applescript
@@ -11,8 +11,8 @@
 
 # Documentation:
 # @raycast.description Close all notification alerts staying on screen, e.g., Calendar notifications.
-# @raycast.author benyn
-# @raycast.authorURL github.com/benyn
+# @raycast.author dlvhdr
+# @raycast.authorURL github.com/dlvhdr
 
 tell application "System Events" to tell application process "NotificationCenter"
 	try

--- a/commands/system/dismiss-notifications.applescript
+++ b/commands/system/dismiss-notifications.applescript
@@ -14,18 +14,16 @@
 # @raycast.author benyn
 # @raycast.authorURL github.com/benyn
 
-tell application "System Events"
-	tell process "NotificationCenter"
-		if not (window "Notification Center" exists) then return
-		set alertGroups to groups of first UI element of first scroll area of first group of window "Notification Center"
-		repeat with aGroup in alertGroups
-			try
-				perform (first action of aGroup whose name contains "Close" or name contains "Clear")
-			on error errMsg
-				log errMsg
-			end try
+tell application "System Events" to tell application process "NotificationCenter"
+	try
+		repeat with uiElement in (actions of UI elements of scroll area 1 of group 1 of group 1 of window "Notification Center" of application process "NotificationCenter" of application "System Events")
+			if description of uiElement contains "Close" then
+				perform uiElement
+			end if
+			if description of uiElement contains "Clear" then
+				perform uiElement
+			end if
 		end repeat
-		-- Show no message on success
-		return ""
-	end tell
+    return ""
+	end try
 end tell


### PR DESCRIPTION
## Description

This dismiss-notifications script stopped working for me on macOS Sequoia.
I've updated the script with the following code.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] New script command
- [x] Bug fix
- [x] Improvement of an existing script
- [ ] Documentation update
- [ ] Toolkit change
- [ ] Other (Specify)

## Screenshot

<!-- If it's a new script command, please include a screenshot or a GIF of how it works. -->

## Dependencies / Requirements

<!-- If it's a new script command that requires some additional steps to make it work, please describe it here. E.g. requiring installation of another command line tool or requirement to specify username / API token / etc. -->

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)