### PR TITLE
feat: add script to open clipboard URLs in Chrome

### DIFF
--- a/commands/browsing/open-clipboard-urls-in-chrome.sh
+++ b/commands/browsing/open-clipboard-urls-in-chrome.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Open URLs in Clipboard in Chrome
+# @raycast.mode silent
+# @raycast.packageName Browsing
+
+# Optional parameters:
+# @raycast.icon 🔗
+
+# Documentation:
+# @raycast.author Michael Bianco
+# @raycast.authorURL https://github.com/iloveitaly
+# @raycast.description Open URLs in Clipboard in Chrome
+
+pbpaste | xargs -n 1 open -a "Google Chrome"


### PR DESCRIPTION
## Description

copy a list of urls, open them all in chrome

## Type of change


- [x] New script command
- [ ] Bug fix
- [ ] Improvement of an existing script
- [ ] Documentation update
- [ ] Toolkit change
- [ ] Other (Specify)

## Screenshot

NA

## Dependencies / Requirements

NA

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)
