### PR TITLE
Added sleep timer script command

### DIFF
--- a/commands/system/sleep-timer.applescript
+++ b/commands/system/sleep-timer.applescript
@@ -1,0 +1,22 @@
+#!/usr/bin/osascript
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Sleep Timer
+# @raycast.mode silent
+# @raycast.description Put your Mac to sleep (in X minutes).
+# @raycast.packageName System
+
+# Optional parameters:
+# @raycast.icon 😴
+# @raycast.argument1 { "optional": true, "type": "text", "placeholder": "(in) minutes" }
+
+# Documentation:
+# @raycast.author AndriiBarabash
+# @raycast.authorURL https://github.com/AndriiBarabash
+
+on run argv
+  delay (item 1 of argv) * 60
+  tell application "Finder" to sleep
+end run
+


### PR DESCRIPTION
## Description

Added a script command that puts Mac to sleep after X minutes. Replicates existing `Sleep` Raycast command but adds a timer.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New script command

## Screenshot

<img width="862" alt="Screenshot 2025-03-10 at 00 21 12" src="https://github.com/user-attachments/assets/19d5065c-b75b-4862-9ef5-209cf60f3f73" />

## Dependencies / Requirements

No dependencies.

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)