### PR TITLE
Update random-emoji to support old bash

### DIFF
--- a/commands/communication/emojis/random-emoji.sh
+++ b/commands/communication/emojis/random-emoji.sh
@@ -24,7 +24,7 @@ if ! command -v jq &> /dev/null; then
       exit 1;
 fi
 
-mapfile -t EMOJIS < <(curl -s https://raw.githubusercontent.com/github/gemoji/master/db/emoji.json | jq -r '.[] | .emoji')
+IFS=$'\n' read -d '' -r -a EMOJIS < <(curl -s https://raw.githubusercontent.com/github/gemoji/master/db/emoji.json | jq -r '.[] | .emoji' && printf '\0')
 EMOJI="${EMOJIS[$RANDOM % ${#EMOJIS[@]}]}"
 echo -n "$EMOJI" | pbcopy
 echo "$EMOJI"


### PR DESCRIPTION

## Description

Old version bash does not support `mapfile` command, so I've changed to use `read` .

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] New script command
- [ ] Bug fix
- [x] Improvement of an existing script
- [ ] Documentation update
- [ ] Toolkit change
- [ ] Other (Specify)

## Screenshot

<!-- If it's a new script command, please include a screenshot or a GIF of how it works. -->

## Dependencies / Requirements

- curl
- jq

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)