### PR TITLE
feat: update dismiss notifications script

### DIFF
--- a/commands/system/dismiss-notifications.applescript
+++ b/commands/system/dismiss-notifications.applescript
@@ -11,19 +11,39 @@
 
 # Documentation:
 # @raycast.description Close all notification alerts staying on screen, e.g., Calendar notifications.
-# @raycast.author dlvhdr
-# @raycast.authorURL github.com/dlvhdr
+# @raycast.author benyn
+# @raycast.authorURL github.com/benyn
 
-tell application "System Events" to tell application process "NotificationCenter"
-	try
-		repeat with uiElement in (actions of UI elements of scroll area 1 of group 1 of group 1 of window "Notification Center" of application process "NotificationCenter" of application "System Events")
-			if description of uiElement contains "Close" then
-				perform uiElement
-			end if
-			if description of uiElement contains "Clear" then
-				perform uiElement
-			end if
+tell application "System Events" to tell process "NotificationCenter"
+	-- Exit if there are no visible notifications.
+	if not (window "Notification Center" exists) then return
+
+	-- `notificationContainer` refers to the UI element (of class `group`) holding notifications and can be either:
+	-- - A single, individual notification, or
+	-- - A collection of individual notifications and groups of stacked notifications.
+	set notificationContainer to a reference to group 1 of scroll area 1 of group 1 of group 1 of window "Notification Center"
+
+	-- If it is a collection, close notifications and groups in reverse order to avoid index changes.
+	set notificationGroups to a reference to groups of notificationContainer
+	repeat with i from (number of notificationGroups) to 1 by -1
+		set g to item i of notificationGroups
+		repeat with a in (actions of g whose description is "Close" or description starts with "Clear")
+			-- Ignore errors that happen if the last remaining item is an individual notification,
+			-- and `notificationCenter` is no longer a `group` of `group`s.
+			-- The final remaining notification will be closed in the second repeat statement below.
+			ignoring application responses
+				perform a
+			end ignoring
 		end repeat
-    return ""
-	end try
+	end repeat
+
+	-- Close the `notificationContainer` itself. This handles:
+	-- - A single, individual notification that was `notificationContainer` from the start, or
+	-- - The last remaining individual notification after the loop above.
+	repeat with a in (actions of notificationContainer whose description is "Close" or description starts with "Clear")
+		perform a
+	end repeat
 end tell
+
+-- Prevent Raycast from displaying the successful result message.
+return


### PR DESCRIPTION
Handle groups of stacked notifications

## Description

The dismiss-notifications script could only handle a single, unstacked notification lingering on screen. This update adds support for clearing groups of stacked notifications.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] New script command
- [ ] Bug fix
- [x] Improvement of an existing script
- [ ] Documentation update
- [ ] Toolkit change
- [ ] Other (Specify)

## Screenshot

<!-- If it's a new script command, please include a screenshot or a GIF of how it works. -->

## Dependencies / Requirements

<!-- If it's a new script command that requires some additional steps to make it work, please describe it here. E.g. requiring installation of another command line tool or requirement to specify username / API token / etc. -->

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)