### PR TITLE
Update reset-launchpad.sh for macOS 15

### DIFF
--- a/commands/system/reset-launchpad.sh
+++ b/commands/system/reset-launchpad.sh
@@ -14,5 +14,5 @@
 # @raycast.author Zach Dawson
 # @raycast.authorURL https://raycast.com/zdawz
 
-defaults write com.apple.dock ResetLaunchPad -bool true
+sudo find 2>/dev/null /private/var/folders/ -type d -name com.apple.dock.launchpad -exec rm -rf {} +
 killall Dock


### PR DESCRIPTION
## Description

This change makes it so that the Reset Launchpad command works on macOS 15.

See https://www.reddit.com/r/mac/comments/1hfzakq/unable_to_reset_launchpad_using_terminal/

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] New script command
- [ ] Bug fix
- [x] Improvement of an existing script
- [ ] Documentation update
- [ ] Toolkit change
- [ ] Other (Specify)

## Screenshot

<!-- If it's a new script command, please include a screenshot or a GIF of how it works. -->

## Dependencies / Requirements

<!-- If it's a new script command that requires some additional steps to make it work, please describe it here. E.g. requiring installation of another command line tool or requirement to specify username / API token / etc. -->

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)