### PR TITLE
Added Reboot and Log out scripts

### DIFF
--- a/commands/system/logout.applescript
+++ b/commands/system/logout.applescript
@@ -1,0 +1,18 @@
+#!/usr/bin/osascript
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Log out
+# @raycast.mode compact
+
+# Optional parameters:
+# @raycast.icon 🚪
+# @raycast.needsConfirmation true
+
+# Documentation:
+# @raycast.description Log out from MacOS session 
+# @raycast.author vadym_ozarynskyi
+# @raycast.authorURL https://github.com/VadimOza
+
+tell application "System Events" to log out
+

--- a/commands/system/reboot.applescript
+++ b/commands/system/reboot.applescript
@@ -1,0 +1,17 @@
+#!/usr/bin/osascript
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Reboot
+# @raycast.mode compact
+
+# Optional parameters:
+# @raycast.icon 🔁
+# @raycast.needsConfirmation true
+
+# Documentation:
+# @raycast.description Reboot your OS
+# @raycast.author vadym_ozarynskyi
+# @raycast.authorURL https://github.com/VadimOza
+
+tell application "System Events" to restart


### PR DESCRIPTION
## Description

From time to time I need to reboot or logout of the mac. It would be very convenient to do that directly from Raycast instead of clicking this by mouse

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] New script command

## Screenshot

Regular reboot/log out by mac os

## Dependencies / Requirements

Only for MacOS

## Checklist

- [X] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)