### PR TITLE
Add natural scrolling toggle script for macOS 15.6.1+

### DIFF
--- a/commands/system/toggle-natural-scrolling-macos15.applescript
+++ b/commands/system/toggle-natural-scrolling-macos15.applescript
@@ -1,0 +1,69 @@
+#!/usr/bin/osascript
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Toggle Natural Scrolling (macOS 15+)
+# @raycast.mode silent
+# @raycast.packageName System
+
+# Optional parameters:
+# @raycast.icon 🖱
+# @raycast.author Raphael-KR
+# @raycast.authorURL https://github.com/Raphael-KR
+# @raycast.description Toggle natural trackpad/mouse scrolling setting for macOS 15.6.1+
+
+set macVersion to system version of (system info)
+
+if macVersion is greater than or equal to "15" then
+	try
+		set isNaturalScrolling to (do shell script "defaults read .GlobalPreferences 'com.apple.swipescrolldirection' 2>/dev/null || echo '1'")
+		
+		if isNaturalScrolling is "1" then
+			do shell script "defaults write .GlobalPreferences 'com.apple.swipescrolldirection' -bool NO"
+			display notification "Natural Scrolling: OFF" with title "Trackpad Settings"
+		else
+			do shell script "defaults write .GlobalPreferences 'com.apple.swipescrolldirection' -bool YES"
+			display notification "Natural Scrolling: ON" with title "Trackpad Settings"
+		end if
+		
+		do shell script "/System/Library/PrivateFrameworks/SystemAdministration.framework/Resources/activateSettings -u"
+		
+	on error e
+		display notification "Using GUI method as fallback" with title "Trackpad Settings"
+		
+		tell application "System Settings"
+			activate
+			set current pane to pane "com.apple.preference.trackpad"
+		end tell
+		
+		delay 0.6
+		
+		tell application "System Events"
+			tell process "System Settings"
+				click radio button 2 of tab group 1 of window "Trackpad"
+				click checkbox 1 of tab group 1 of window "Trackpad"
+			end tell
+		end tell
+		
+		tell application "System Settings" to quit
+	end try
+	
+else
+	display notification "For macOS 14 and earlier, use the original script" with title "Compatibility Note"
+	
+	tell application "System Settings"
+		activate
+		set current pane to pane "com.apple.preference.trackpad"
+	end tell
+	
+	delay 0.6
+	
+	tell application "System Events"
+		tell process "System Settings"
+			click radio button 2 of tab group 1 of window "Trackpad"
+			click checkbox 1 of tab group 1 of window "Trackpad"
+		end tell
+	end tell
+	
+	tell application "System Settings" to quit
+end if


### PR DESCRIPTION
## Problem
The existing `toggle-natural-scrolling.applescript` fails on macOS 15.6.1+ with error:
```
The domain/default pair of (kCFPreferencesAnyApplication, com.apple.swipescrolldirection) does not exist
```

## Solution
Added a new script `toggle-natural-scrolling-macos15.applescript` specifically for macOS 15+, while **preserving the original script** for backward compatibility.

## Why a Separate File?
- **Preserve existing functionality** for macOS 14 and earlier users
- **Clear version targeting** - users know which script to use  
- **Safe migration path** - no risk of breaking existing setups
- **Future-proof approach** - easier to maintain version-specific fixes

## Technical Discovery
Through systematic debugging, we found that macOS 15.6.1+ changed the storage location:

**Old location (macOS ≤14):**
```bash
defaults -currentHost read NSGlobalDomain com.apple.swipescrolldirection
```

**New location (macOS 15+):**
```bash
defaults read .GlobalPreferences 'com.apple.swipescrolldirection'
```

## Key Features
- ✅ **Works on macOS 15.6.1+** with the correct domain
- ✅ **Visual feedback** with notifications
- ✅ **Robust fallback** to GUI method if defaults fail  
- ✅ **Version check** with appropriate messaging
- ✅ **Immediate application** of settings

## Testing Results  
- ✅ **macOS 15.6.1 (24G90)**: Perfect functionality
- ✅ **Error handling**: Graceful fallback to GUI method
- ✅ **User experience**: Clear notifications and instant application

## Type of change
- [x] New script command
- [x] Bug fix