### PR TITLE
Add reboot script for macOS

### DIFF
--- a/commands/system/reboot.sh
+++ b/commands/system/reboot.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Reboot
+# @raycast.mode silent
+
+# Optional parameters:
+# @raycast.icon 🔄
+# @raycast.packageName System
+
+# Documentation:
+# @raycast.description Reboot macOS with a clean session (apps will not be restored).
+# @raycast.author Ninh Hai Dang
+# @raycast.authorURL https://github.com/ninhhaidang
+
+# Disable saving app state before restart
+defaults write com.apple.loginwindow TALLogoutSavesState -bool false
+defaults write com.apple.loginwindow LoginwindowLaunchesRelaunchApps -bool false
+
+# Trigger reboot
+osascript -e 'tell application "loginwindow" to «event aevtrrst»'

--- a/commands/system/reboot.sh
+++ b/commands/system/reboot.sh
@@ -14,9 +14,15 @@
 # @raycast.author Ninh Hai Dang
 # @raycast.authorURL https://github.com/ninhhaidang
 
+# Check if running on macOS
+if [[ "$OSTYPE" != "darwin"* ]]; then
+    echo "Error: This script only works on macOS"
+    exit 1
+fi
+
 # Disable saving app state before restart
 defaults write com.apple.loginwindow TALLogoutSavesState -bool false
 defaults write com.apple.loginwindow LoginwindowLaunchesRelaunchApps -bool false
 
-# Trigger reboot
+# Trigger reboot with confirmation
 osascript -e 'tell application "loginwindow" to «event aevtrrst»'

--- a/commands/system/reboot.sh
+++ b/commands/system/reboot.sh
@@ -14,9 +14,11 @@
 # @raycast.author Ninh Hai Dang
 # @raycast.authorURL https://github.com/ninhhaidang
 
+set -euo pipefail
+
 # Check if running on macOS
 if [[ "$OSTYPE" != "darwin"* ]]; then
-    echo "Error: This script only works on macOS"
+    echo "This script only works on macOS"
     exit 1
 fi
 
@@ -24,5 +26,5 @@ fi
 defaults write com.apple.loginwindow TALLogoutSavesState -bool false
 defaults write com.apple.loginwindow LoginwindowLaunchesRelaunchApps -bool false
 
-# Trigger reboot with confirmation
+# Trigger reboot
 osascript -e 'tell application "loginwindow" to «event aevtrrst»'


### PR DESCRIPTION
## What does this script do?
This script provides a clean reboot for macOS that doesn't restore previously opened applications.

## Why is this script useful?
- Provides a clean restart without app restoration
- Useful for troubleshooting when you want a fresh session
- Saves time compared to manually disabling app restoration in System Preferences
- Helps when you need a completely fresh macOS session

## Additional context
- Script uses safe AppleScript commands to trigger reboot
- Automatically disables app state saving before restart
- No dependencies required, works with standard macOS tools
- Safe and non-destructive operation

## Testing
- [x] Tested on macOS
- [x] Script follows Raycast Script Commands guidelines
- [x] Proper metadata and documentation included