### PR TITLE
Added Kill Processes Running od specific ports

### DIFF
--- a/commands/system/kill-a-process-on-port.sh
+++ b/commands/system/kill-a-process-on-port.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Kill a process on PORT
+# @raycast.mode compact
+
+# Optional parameters:
+# @raycast.icon 🚫
+# @raycast.argument1 { "type": "text", "placeholder": "Ports (e.g. 3000 5000)" }
+
+# Documentation:
+# @raycast.description Kill running processes on the given ports
+# @raycast.author aaqifshafi
+# @raycast.authorURL https://github.com/aaqifshafi
+
+if [ $# -eq 0 ]; then
+  echo "Provide at least one port number."
+  exit 1
+fi
+
+for port in "$@"
+do
+  pid=$(lsof -ti tcp:$port)
+  if [ -n "$pid" ]; then
+    kill -9 $pid
+    echo "Killed process $pid on port $port"
+  else
+    echo "No process found on port $port"
+  fi
+done


### PR DESCRIPTION
## Description

This PR adds a new script command to quickly kill any process running on one or more given ports.
It’s useful for developers who frequently need to stop apps (e.g. Node, Next.js, React, etc.) that are stuck running on ports like 3000, 5000, etc.

The script accepts one or multiple ports as arguments and kills the processes with clear success/failure messages.

## Type of change

- [x] New script command

## Screenshot

![CleanShot 2025-10-01 at 19 36 32](https://github.com/user-attachments/assets/745e4269-d983-4fb4-adc8-996c389d93ec)

## Dependencies / Requirements

Requires lsof (preinstalled on macOS).
No other dependencies.
Works out of the box on macOS with Raycast.

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)