### PR TITLE
Added delay to paste

### DIFF
--- a/commands/system/paste-clipboard.sh
+++ b/commands/system/paste-clipboard.sh
@@ -14,8 +14,30 @@
 # @raycast.author AlexGadd
 # @raycast.authorURL https://raycast.com/AlexGadd
 
+sleep 0.3
+#returns "true" or "false" if key is held down
+commandKeyDown=$(osascript -l JavaScript -e "ObjC.import('Cocoa'); ($.NSEvent.modifierFlags & $.NSEventModifierFlagCommand) > 1")
+controlKeyDown=$(osascript -l JavaScript -e "ObjC.import('Cocoa'); ($.NSEvent.modifierFlags & $.NSEventModifierFlagControl) > 1")
+optionKeyDown=$(osascript -l JavaScript -e "ObjC.import('Cocoa'); ($.NSEvent.modifierFlags & $.NSEventModifierFlagOption) > 1")
+shiftKeyDown=$(osascript -l JavaScript -e "ObjC.import('Cocoa'); ($.NSEvent.modifierFlags & $.NSEventModifierFlagShift) > 1")
+functionKeyDown=$(osascript -l JavaScript -e "ObjC.import('Cocoa'); ($.NSEvent.modifierFlags & $.NSEventModifierFlagFunction) > 1")
+
+keys=("$commandKeyDown" "$controlKeyDown" "$optionKeyDown" "$shiftKeyDown" "$functionKeyDown")
+
+anyPressed=false
+for key in "${keys[@]}"; do
+  if [[ $key == "true" ]]; then
+    anyPressed=true
+    break
+  fi
+done
+
+if $anyPressed; then
+osascript -e 'set theAlertText to "Modifier key held"' \
+-e 'set theAlertMessage to "To allow this script to function, please ensure you do not hold any modifier keys down while the paste script runs"' \
+-e 'display alert theAlertText message theAlertMessage as critical buttons {"OK"} default button "OK"' \
+else
 osascript -e 'set clipboardContent to the clipboard' \
--e 'delay 0.2' \
 -e 'set charCount to count of characters of clipboardContent' \
 -e 'tell application "System Events"' \
 -e '	repeat with i from 1 to charCount' \
@@ -23,3 +45,4 @@ osascript -e 'set clipboardContent to the clipboard' \
 -e '		keystroke theChar' \
 -e '	end repeat' \
 -e 'end tell'
+fi


### PR DESCRIPTION
If keys are still held down while it starts typing this can trigger commands or alternative characters to be typed, may need to add a description to warn people if they don't understand how this script works? Not sure if that's standard practice for these commits

## Description

<!-- Please write a short summary for this change. If it's a new script command, explain what it does. -->

## Type of change

If keys are still being held down it can cause unexpected outcomes so I added a delay before it starts "typing"

- [ ] New script command
- [ ] Bug fix
- [x] Improvement of an existing script
- [ ] Documentation update
- [ ] Toolkit change
- [ ] Other (Specify)

## Screenshot

<!-- If it's a new script command, please include a screenshot or a GIF of how it works. -->

## Dependencies / Requirements

<!-- If it's a new script command that requires some additional steps to make it work, please describe it here. E.g. requiring installation of another command line tool or requirement to specify username / API token / etc. -->

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)