### PR TITLE
Add script to delete selected files in Finder

### DIFF
--- a/commands/system/delete-selected-files.sh
+++ b/commands/system/delete-selected-files.sh
@@ -11,7 +11,7 @@
 
 # Documentation:
 # @raycast.description Move selected files in Finder to Trash
-# @raycast.author Vicent
+# @raycast.author Vicent Gozalbes
 # @raycast.authorURL https://github.com/vigosan
 
 file_count=$(osascript <<'ENDAPPLE'


### PR DESCRIPTION
## Description

This script allows users to quickly move selected files or folders to the Trash directly from Finder. Unlike existing trash scripts that operate on entire directories (Desktop, Downloads), this command works with any files/folders currently selected in Finder, making it more flexible and user-friendly.

Features:
- Works with multiple selected items (files and folders)
- Handles filenames with spaces correctly
- Executes silently without confirmation for quick workflow
- Uses native Finder trash functionality

## Type of change

- [x] New script command
- [ ] Bug fix
- [ ] Improvement of an existing script
- [ ] Documentation update
- [ ] Toolkit change
- [ ] Other (Specify)

## Screenshot

<img width="1724" height="1172" alt="CleanShot 2025-10-25 at 12 52 59@2x" src="https://github.com/user-attachments/assets/b9a558a3-6fd9-4a0a-918e-c24075672cee" />
_Screenshot showing the command appearing in Raycast with the System package icon._

## Dependencies / Requirements

None. This script uses only native macOS tools:
- Bash (built-in)
- AppleScript/osascript (built-in)
- Finder (built-in)

No additional installation or configuration required.

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)