### PR TITLE
Add qpdf compression command tool

### DIFF
--- a/commands/productivity/qpdf/compress-pdf-qpdf.sh
+++ b/commands/productivity/qpdf/compress-pdf-qpdf.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Dependency: This script requires `qpdf` installed: https://github.com/qpdf/qpdf
+# Install via homebrew: `brew install qpdf`
+
 # Required parameters:
 # @raycast.schemaVersion 1
 # @raycast.title Compress PDF


### PR DESCRIPTION
Description
This script command compresses selected PDF files in Finder using qpdf.

It prompts the user to input a desired JPEG quality percentage (0-100). The script applies aggressive compression settings (re-compressing streams and images) to reduce file size. The output file is saved in the same directory as the original, with the chosen quality percentage appended to the filename (e.g., MyDocument_50%.pdf), making it easy to identify the compression level.

Type of change
[x] New script command

[ ] Bug fix

[ ] Improvement of an existing script

[ ] Documentation update

[ ] Toolkit change

[ ] Other (Specify)

Screenshot
Dependencies / Requirements
This script requires qpdf to be installed. It can be installed via Homebrew:

Bash

brew install qpdf
The script automatically checks if qpdf is installed and alerts the user if it is missing.

Checklist
[x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)