### PR TITLE
Add BNF Search Script

### DIFF
--- a/commands/web-searches/bnf-search.sh
+++ b/commands/web-searches/bnf-search.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title BNF Search
+# @raycast.mode silent
+
+# Optional parameters:
+# @raycast.icon 💊
+# @raycast.packageName Medical
+# @raycast.argument1 { "type": "dropdown", "placeholder": "Source", "data": [{"title": "BNF (Adults)", "value": "bnf"}, {"title": "BNFC (Children)", "value": "bnfc"}] }
+# @raycast.argument2 { "type": "text", "placeholder": "Medication (e.g. Paracetamol)" }
+
+# Documentation:
+# @raycast.description Search the British National Formulary (BNF) or BNFC directly.
+# @raycast.author Jack Smith
+# @raycast.authorURL https://github.com/myusualonewastaken
+
+SOURCE="$1"
+INPUT="$2"
+
+if [ "$SOURCE" == "bnfc" ]; then
+    BASE_DOMAIN="bnfc.nice.org.uk"
+else
+    BASE_DOMAIN="bnf.nice.org.uk"
+fi
+
+# Clean up input: Lowercase, replace spaces with dashes
+SLUG=$(echo "$INPUT" | tr '[:upper:]' '[:lower:]' | tr ' ' '-')
+
+DIRECT_URL="https://$BASE_DOMAIN/drugs/$SLUG/"
+SEARCH_URL="https://$BASE_DOMAIN/search?q=$INPUT"
+
+# Check URL with a fake User-Agent to avoid being blocked
+# -o /dev/null: Ignore the page content
+# --silent: Don't show loading bars
+# --head: Only check the headers
+# --write-out '%{http_code}': Tell us the status code (e.g., 200 or 404)
+STATUS=$(curl -o /dev/null --silent --head --write-out '%{http_code}' -A "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)" "$DIRECT_URL")
+
+# If the status is 200 (OK), open the direct page. Otherwise, search.
+if [ "$STATUS" -eq 200 ]; then
+  open "$DIRECT_URL"
+else
+  open "$SEARCH_URL"
+fi


### PR DESCRIPTION
## Description

New script command that allows searching for a medication on the British National Formulary. It allows for selection of both BNF and BNFC (for children).

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] New script command

## Screenshot

<!-- If it's a new script command, please include a screenshot or a GIF of how it works. -->
Y
## Dependencies / Requirements

<!-- If it's a new script command that requires some additional steps to make it work, please describe it here. E.g. requiring installation of another command line tool or requirement to specify username / API token / etc. -->
None

## Checklist

- [X] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)

https://github.com/user-attachments/assets/69ef3b9c-648a-4d4f-aff2-cce1928adf88

