### PR TITLE
Update safari-create-reading-list-item.applescript

### DIFF
--- a/commands/apps/safari/safari-create-reading-list-item.applescript
+++ b/commands/apps/safari/safari-create-reading-list-item.applescript
@@ -8,7 +8,7 @@
 # Optional parameters:
 # @raycast.packageName Safari
 # @raycast.icon images/safari.png
-# @raycast.argument1 { "type": "text", "placeholder": "Link, use open for current page" }
+# @raycast.argument1 { "type": "text", "placeholder": "Link, use 'open' for current Safari page" }
 # @raycast.argument2 { "type": "text", "placeholder": "Title", "optional": true }
 
 # @Documentation:

--- a/commands/apps/safari/safari-create-reading-list-item.applescript
+++ b/commands/apps/safari/safari-create-reading-list-item.applescript
@@ -13,7 +13,10 @@
 
 # @Documentation:
 # @raycast.author Thomas Paul Mann
+# @raycast.author Thomas Paul Mann
 # @raycast.authorURL https://github.com/thomaspaulmann
+# @raycast.author JNBARY
+# @raycast.authorURL https://github.com/JNBARY
 # @raycast.description Add a new Reading List item with the given URL. Allows a custom title to be specified.
 
 on run argv

--- a/commands/apps/safari/safari-create-reading-list-item.applescript
+++ b/commands/apps/safari/safari-create-reading-list-item.applescript
@@ -8,7 +8,7 @@
 # Optional parameters:
 # @raycast.packageName Safari
 # @raycast.icon images/safari.png
-# @raycast.argument1 { "type": "text", "placeholder": "Link" }
+# @raycast.argument1 { "type": "text", "placeholder": "Link, use open for current page" }
 # @raycast.argument2 { "type": "text", "placeholder": "Title", "optional": true }
 
 # @Documentation:
@@ -20,6 +20,12 @@ on run argv
   try
     set linkArgument to item 1 of argv as text
     set titleArgument to item 2 of argv as text
+
+    if linkArgument is equal to "open" then
+      tell application "Safari"
+        set linkArgument to URL of current tab of window 1 as text
+      end tell
+    end if
 
     if titleArgument is equal to "" then
       tell application "Safari" to add reading list item linkArgument


### PR DESCRIPTION
## Description

Modified the script to optionally use the URL of the webpage currently open in Safari as Link for the new Reading List item.

## Type of change

- [X] Improvement of an existing script


## Screenshot

By using "open" for the "Link"-argument the webpage currently open in Safari will be added to the Reading List.

## Dependencies / Requirements

No additional steps needed during installation.

## Checklist

- [X] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)