### PR TITLE
Prefer HTML pasteboard flavor in rich-text-to-markdown for hyperlinked text fidelity

### DIFF
--- a/commands/conversions/rich-text-clipboard-to-markdown.sh
+++ b/commands/conversions/rich-text-clipboard-to-markdown.sh
@@ -6,7 +6,7 @@
 # @raycast.title Rich Text to Markdown
 # @raycast.author Adam Zethraeus
 # @raycast.authorURL https://github.com/adam-zethraeus
-# @raycast.description Convert rich text clipboard data to GitHub Flavored Markdown using Pandoc
+# @raycast.description Convert rich text clipboard data (preserving hyperlinked text as [label](url)) to GitHub Flavored Markdown using Pandoc. Tries the HTML pasteboard flavor first, falls back to RTF.
 #
 # @raycast.icon 📝
 #
@@ -20,4 +20,19 @@ if ! command -v pandoc &> /dev/null; then
 fi
 
 export LC_CTYPE=UTF-8
+
+# Prefer HTML: most modern web sources (browsers, Gmail, Google Docs, Notion,
+# Linear, etc.) place higher-fidelity HTML on the pasteboard than RTF, and it
+# preserves hyperlinked text as real anchor tags that pandoc renders as
+# [label](url) in markdown.
+html=$(osascript -e 'try' -e 'the clipboard as «class HTML»' -e 'on error' -e 'return ""' -e 'end try' 2>/dev/null \
+  | perl -ne 'chomp; next unless s/^«data HTML//; s/»$//; print pack("H*", $_)')
+
+if [ -n "$html" ]; then
+    printf '%s' "$html" | pandoc --from=html --to=gfm | pbcopy
+    exit 0
+fi
+
+# Fall back to RTF for sources that only expose rich text (some native apps,
+# older editors). This is the original behavior of the script.
 osascript -e 'the clipboard as «class RTF »' | perl -ne 'print chr foreach unpack("C*",pack("H*",substr($_,11,-3)))' | pandoc --from=rtf --to=gfm | pbcopy


### PR DESCRIPTION
## Description

Extends `commands/conversions/rich-text-clipboard-to-markdown.sh` to prefer the **HTML** pasteboard flavor over the **RTF** flavor, with the original RTF pipeline kept as a fallback.

### Why

When you copy hyperlinked text from modern web sources (browsers, Gmail, Google Docs, Notion, Linear, Slack web, etc.), macOS puts both an RTF and an HTML flavor on the pasteboard. The HTML flavor carries the hyperlinks as real anchor tags, which pandoc renders cleanly as `[label](url)` in markdown. The RTF flavor from the same sources often drops or mangles those links, leaving the visible text intact but stripping the URL.

For anyone who frequently pastes rich text into CLIs or plain-text editors (Claude Code, terminals, vim, etc.), the HTML path meaningfully reduces link loss.

### Before / after

Copy from a webpage:

> Check out [Raycast](https://raycast.com) and [Anthropic](https://anthropic.com).

**Before (RTF path):** hyperlinks often stripped, only visible text survives.

**After (HTML path):**

\`\`\`
Check out [Raycast](https://raycast.com) and [Anthropic](https://anthropic.com).
\`\`\`

### Backward compatibility

No breaking changes. When HTML is absent from the pasteboard (some native apps, older editors), the script falls through to the original RTF pipeline unchanged.

## Type of change

- [x] Improvement of an existing script

## Dependencies / Requirements

Unchanged — still only requires `pandoc` (`brew install pandoc`).

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)